### PR TITLE
Add Cherry ST-1506 RMI get_info support

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -126,22 +126,39 @@ class CardsController < ApplicationController
       status  = :alert
       message = "CardTerminal #{ct} pin mode == off"
     else
-      # start background rmi job
-      CardTerminals::RMI::VerifyPinJob.perform_later(card: @card)
-      # wait some time
-      sleep 3
-
-      # start verify pin
-      result = Cocard::VerifyPin.new(card: @card, context: set_context).call
-      unless result.success?
-        status  = :alert
-        message = (@card.to_s + "<br/>" +
-                            "Kontext: #{@context}<br/>ERROR:: " +
-                            result.error_messages.join(', ')).html_safe
+      rmi = ct.rmi
+      if rmi.supported? && rmi.available_actions.include?(:verify_pin_while)
+        rmi_status = rmi.verify_pin_while(@card.iccsn) do
+          Cocard::VerifyPinWithSt1506Retry.new(card: @card, context: set_context).call
+        end
+        result = nil
+        rmi_status.on_success { |_message, value| result = value }
+        rmi_status.on_failure do |rmi_message|
+          status  = :alert
+          message = (@card.to_s + "<br/>" +
+                     "Kontext: #{@context}<br/>ERROR:: " + rmi_message).html_safe
+        end
       else
-        status  = :success
-        message = (@card.to_s + "<br/>" + "Kontext: #{@context}<br/>" +
-                   "VERIFY PIN successful").html_safe
+        # start background rmi job
+        CardTerminals::RMI::VerifyPinJob.perform_later(card: @card)
+        # wait some time
+        sleep 3
+
+        # start verify pin
+        result = Cocard::VerifyPin.new(card: @card, context: set_context).call
+      end
+
+      if result
+        unless result.success?
+          status  = :alert
+          message = (@card.to_s + "<br/>" +
+                              "Kontext: #{@context}<br/>ERROR:: " +
+                              result.error_messages.join(', ')).html_safe
+        else
+          status  = :success
+          message = (@card.to_s + "<br/>" + "Kontext: #{@context}<br/>" +
+                     "VERIFY PIN successful").html_safe
+        end
       end
     end
 

--- a/app/models/cocard/pin_verify.rb
+++ b/app/models/cocard/pin_verify.rb
@@ -1,7 +1,7 @@
 module Cocard
   class PinVerify
 
-    ATTRIBUTES = %i( pin_result status error_text left_tries )
+    ATTRIBUTES = %i( pin_result status error_code error_text left_tries )
 
     def initialize(hash)
       @hash = hash || {}
@@ -19,8 +19,12 @@ module Cocard
       hash.dig(:status, :result)
     end
 
+    def error_code
+      trace_value(:code)
+    end
+
     def error_text
-      hash.dig(:status, :error, :trace, :error_text)
+      trace_value(:error_text)
     end
 
     def left_tries
@@ -29,5 +33,10 @@ module Cocard
 
   private
     attr_reader :hash
+
+    def trace_value(key)
+      trace = hash.dig(:status, :error, :trace) || hash.dig('status', 'error', 'trace') || {}
+      trace[key] || trace[key.to_s]
+    end
   end
 end

--- a/app/services/card_terminals/rmi.rb
+++ b/app/services/card_terminals/rmi.rb
@@ -94,6 +94,17 @@ module CardTerminals
       end
     end
 
+    def verify_pin_while(iccsn, &block)
+      return Status.unsupported unless supported? && available_actions.include?(:verify_pin_while)
+
+      result = rmi.verify_pin_while(iccsn, &block)
+      if result.success?
+        Status.success(result.message.to_s, result.value)
+      else
+        Status.failure(result.message.to_s)
+      end
+    end
+
     def remote_pairing
       timeout = 30
       if supported? && available_actions.include?(:remote_pairing)

--- a/app/services/card_terminals/rmi/cherry_v1.rb
+++ b/app/services/card_terminals/rmi/cherry_v1.rb
@@ -26,7 +26,7 @@ module CardTerminals
       def available_actions
         return [] unless supported?
 
-        %i[ verify_pin ]
+        %i[ verify_pin get_info ]
       end
 
       def supported?
@@ -39,6 +39,18 @@ module CardTerminals
 
       def verify_pin(iccsn)
         self.class.with_verify_pin_lock(card_terminal.id) { verify_pin_without_lock(iccsn) }
+      end
+
+      def get_info
+        unless rmi_port_reachable?
+          return Result.new(success?: false, message: "RMI-Port #{rmi_port} unreachable!")
+        end
+
+        if ws_auth_pass.blank?
+          return Result.new(success?: false, message: 'DEFAULT_WS_AUTH_PASS is not configured!')
+        end
+
+        fetch_device_information
       end
 
       def verify_pin_without_lock(iccsn)
@@ -122,6 +134,146 @@ module CardTerminals
 
     private
       attr_reader :request
+
+      def fetch_device_information
+        @result = {}
+        @session = {}
+        @request = Request.new(session)
+        pending = {}
+        attempted_logout = false
+
+        self.class.with_eventmachine_lock do
+          EM.run do
+            ws = Faye::WebSocket::Client.new(ws_url, ['cobra'], ping: 15, tls: tls_options)
+            send_request = lambda do |message, action|
+              msg_id = JSON.parse(message).dig('header', 'msgId')
+              pending[msg_id] = action
+              ws.send(message)
+            end
+            close_after_logout = lambda do
+              if session[:management_session_id].present? && !attempted_logout
+                attempted_logout = true
+                send_request.call(request.logout, :logout)
+              else
+                ws.close
+              end
+            end
+            timeout = EM::Timer.new(15) do
+              if @result[:message].blank? && !@result[:success]
+                @result = { success: false, message: 'Timeout while requesting device information' }
+              end
+              close_after_logout.call
+            end
+
+            ws.on :open do |_event|
+              debug('>>> :open cherry remote management get-info >>>')
+              send_request.call(request.login(ws_auth_user, ws_auth_pass), :login)
+            end
+
+            ws.on :message do |event|
+              response = parse_ws_response(event.data)
+              unless response
+                if session[:management_session_id].present? && !attempted_logout
+                  attempted_logout = true
+                  send_request.call(request.logout, :logout)
+                else
+                  ws.close
+                end
+                next
+              end
+
+              debug2(response)
+              action = pending[response.in_reply_to_id]
+              if response.in_reply_to_id.blank? || action.blank?
+                if @result[:success] && attempted_logout
+                  ws.close
+                  next
+                end
+
+                @result = {
+                  success: false,
+                  message: "Unexpected ST-1506 management response: unknown inReplyToId #{response.in_reply_to_id.presence || '(missing)'}"
+                }
+                close_after_logout.call
+                next
+              end
+
+              unless response.success?
+                if action == :logout
+                  ws.close
+                  next
+                end
+
+                @result = { success: false, message: response.error.to_s }
+                if session[:management_session_id].present? && action != :login && !attempted_logout
+                  attempted_logout = true
+                  send_request.call(request.logout, :logout)
+                else
+                  ws.close
+                end
+                next
+              end
+
+              case action
+              when :login
+                if response.payload_type != 'LoginResponse'
+                  @result = { success: false, message: "Unexpected ST-1506 management response for LoginRequest: #{response.payload_type}" }
+                  ws.close
+                elsif response.session_id.blank?
+                  @result = { success: false, message: 'Login response did not contain a session id' }
+                  ws.close
+                else
+                  session[:management_session_id] = response.session_id
+                  send_request.call(request.get_device_information, :get_device_information)
+                end
+              when :get_device_information
+                information = response.device_information
+                if response.get_device_information_response? && information.present?
+                  @result = {
+                    success: true,
+                    message: 'Device information received',
+                    value: Info.new(information)
+                  }
+                  attempted_logout = true
+                  send_request.call(request.logout, :logout)
+                else
+                  @result = { success: false, message: "Unexpected ST-1506 management response for GetDeviceInformationRequest: #{response.payload_type}" }
+                  if session[:management_session_id].present? && !attempted_logout
+                    attempted_logout = true
+                    send_request.call(request.logout, :logout)
+                  else
+                    ws.close
+                  end
+                end
+              when :logout
+                ws.close
+              else
+                @result = { success: false, message: "Unexpected ST-1506 management action #{action}" }
+                close_after_logout.call
+              end
+            end
+
+            ws.on :error do |event|
+              @result = { success: false, message: event.message } unless @result[:success]
+              debug([:error, event.message])
+              close_after_logout.call
+            end
+
+            ws.on :close do |event|
+              timeout.cancel if timeout
+              debug([:close, event.code, event.reason])
+              ws = nil
+              EM.stop
+            end
+          end
+        end
+
+        if @result[:success]
+          Result.new(success?: true, message: @result[:message], value: @result[:value])
+        else
+          Result.new(success?: false, message: @result[:message] || 'Could not request device information')
+        end
+      end
 
       def fetch_smcb_authentication_key
         @result = {}
@@ -347,7 +499,7 @@ module CardTerminals
       def parse_ws_response(data)
         Response.new(data)
       rescue JSON::ParserError => e
-        @result = { success: false, message: "Invalid JSON from ST-1506: #{e.message}" }
+        @result = { success: false, message: "Invalid JSON from ST-1506: #{e.message}" } unless @result[:success]
         nil
       end
 

--- a/app/services/card_terminals/rmi/cherry_v1.rb
+++ b/app/services/card_terminals/rmi/cherry_v1.rb
@@ -26,7 +26,7 @@ module CardTerminals
       def available_actions
         return [] unless supported?
 
-        %i[ verify_pin get_info ]
+        %i[ verify_pin verify_pin_while get_info ]
       end
 
       def supported?
@@ -39,6 +39,14 @@ module CardTerminals
 
       def verify_pin(iccsn)
         self.class.with_verify_pin_lock(card_terminal.id) { verify_pin_without_lock(iccsn) }
+      end
+
+      def verify_pin_while(iccsn, &block)
+        unless block_given?
+          return Result.new(success?: false, message: 'Block is required for ST-1506 PIN verification')
+        end
+
+        self.class.with_verify_pin_lock(card_terminal.id) { verify_pin_while_without_lock(iccsn, &block) }
       end
 
       def get_info
@@ -54,29 +62,20 @@ module CardTerminals
       end
 
       def verify_pin_without_lock(iccsn)
-        unless rmi_port_reachable?
-          return Result.new(success?: false, message: "RMI-Port #{rmi_port} unreachable!")
-        end
+        preflight = verify_pin_preflight(iccsn)
+        return preflight unless preflight.success?
 
-        unless valid_smcb_pin?
-          return Result.new(success?: false, message: 'DEFAULT_SMCB_PIN must be 6 to 8 digits!')
-        end
-        if ws_auth_pass.blank?
-          return Result.new(success?: false, message: 'DEFAULT_WS_AUTH_PASS is not configured!')
-        end
-
-        card_slot_result = card_terminal_slot_for(iccsn)
-        return card_slot_result unless card_slot_result.success?
-
-        key_result = fetch_smcb_authentication_key
-        return key_result unless key_result.success?
-        unless valid_hex?(key_result.value, 64)
-          return Result.new(success?: false, message: 'Invalid ST-1506 SMC-B authentication key')
-        end
-
-        connect_remote_smcb_api(key_result.value, card_slot_result.value.slotid)
+        connect_remote_smcb_api(preflight.value[:key], preflight.value[:slot_id])
       end
       private :verify_pin_without_lock
+
+      def verify_pin_while_without_lock(iccsn, &block)
+        preflight = verify_pin_preflight(iccsn)
+        return preflight unless preflight.success?
+
+        connect_remote_smcb_api_while(preflight.value[:key], preflight.value[:slot_id], &block)
+      end
+      private :verify_pin_while_without_lock
 
       def self.with_verify_pin_lock(terminal_id)
         body_started = false
@@ -362,6 +361,33 @@ module CardTerminals
         end
       end
 
+      def verify_pin_preflight(iccsn)
+        unless rmi_port_reachable?
+          return Result.new(success?: false, message: "RMI-Port #{rmi_port} unreachable!")
+        end
+
+        unless valid_smcb_pin?
+          return Result.new(success?: false, message: 'DEFAULT_SMCB_PIN must be 6 to 8 digits!')
+        end
+        if ws_auth_pass.blank?
+          return Result.new(success?: false, message: 'DEFAULT_WS_AUTH_PASS is not configured!')
+        end
+
+        card_slot_result = card_terminal_slot_for(iccsn)
+        return card_slot_result unless card_slot_result.success?
+
+        key_result = fetch_smcb_authentication_key
+        return key_result unless key_result.success?
+        unless valid_hex?(key_result.value, 64)
+          return Result.new(success?: false, message: 'Invalid ST-1506 SMC-B authentication key')
+        end
+
+        Result.new(success?: true, message: 'ST-1506 PIN verification preflight complete', value: {
+          key: key_result.value,
+          slot_id: card_slot_result.value.slotid
+        })
+      end
+
       def connect_remote_smcb_api(key, authorized_slot_id)
         @result = {}
         @session = {}
@@ -488,12 +514,221 @@ module CardTerminals
         end
       end
 
+      def connect_remote_smcb_api_while(key, authorized_slot_id)
+        @result = {}
+        @session = {}
+        @request = Request.new(session)
+        listener_ready_events = Queue.new
+        auth_events = Queue.new
+        pending_pin_notifies = 0
+        block_finished = false
+        block_value = nil
+        authenticated = false
+        listener_ready_signaled = false
+        auth_signaled = false
+        closed = false
+        ws = nil
+        close_when_block_done = nil
+
+        signal_listener_ready = lambda do
+          next if listener_ready_signaled
+
+          listener_ready_signaled = true
+          listener_ready_events << true
+        end
+        signal_auth = lambda do |status|
+          next if auth_signaled
+
+          auth_signaled = true
+          auth_events << status
+        end
+        close_listener = lambda do
+          listener_ws = ws
+          next unless listener_ws
+
+          schedule_on_eventmachine do
+            listener_ws.close
+          end
+        end
+
+        listener_thread = Thread.new do
+          execute_with_rails_executor do
+            self.class.with_eventmachine_lock do
+              signal_listener_ready.call
+
+              EM.run do
+                ws = Faye::WebSocket::Client.new(ws_url, ['cobra-smcb'], ping: 15, tls: tls_options)
+                auth_timeout = EM::Timer.new(smcb_total_timeout_seconds) do
+                  next if authenticated || @result[:success] || @result[:message].present?
+
+                  @result = { success: false, message: 'Timeout during ST-1506 block PIN verification' }
+                  signal_auth.call(:failed)
+                  ws.close
+                end
+
+                close_when_block_done = lambda do
+                  next if closed
+                  next unless block_finished && pending_pin_notifies.zero?
+
+                  @result = { success: true, message: 'PIN Verification complete', value: block_value } unless @result[:message].present?
+                  ws.close
+                end
+                close_with_failure = lambda do |message|
+                  next if closed
+
+                  @result = { success: false, message: message }
+                  signal_auth.call(:failed) unless authenticated
+                  ws.close
+                end
+
+                ws.on :open do |_event|
+                  debug('>>> :open cherry remote SMC-B block >>>')
+                end
+
+                ws.on :message do |event|
+                  response = parse_ws_response(event.data)
+                  unless response
+                    signal_auth.call(:failed) unless authenticated
+                    ws.close
+                    next
+                  end
+
+                  debug2(response)
+                  session[:smcb_session_id] = response.session_id if response.session_id.present?
+
+                  if response.authenticate_request?
+                    unless valid_authenticate_request?(response)
+                      close_with_failure.call('Invalid ST-1506 SMC-B authenticate request')
+                      next
+                    end
+
+                    cmac = self.class.aes_cmac_hex(key, response.challenge)
+                    ws.send(request.authenticate_response(response.msg_id, cmac))
+                    authenticated = true
+                    auth_timeout.cancel if auth_timeout
+                    auth_timeout = nil
+                    signal_auth.call(:authenticated)
+                  elsif !authenticated
+                    close_with_failure.call("Unexpected ST-1506 SMC-B response before authentication: #{response.payload_type}")
+                  elsif response.notify?
+                    if response.success?
+                      pending_pin_notifies -= 1 if pending_pin_notifies.positive?
+                      close_when_block_done.call
+                    else
+                      close_with_failure.call("ST-1506 notify code #{response.notify_code}")
+                    end
+                  elsif response.input_pin_request?
+                    unless authorized_pin_request?(response, authorized_slot_id)
+                      close_with_failure.call('ST-1506 PIN request slot is not authorized for this card')
+                      next
+                    end
+
+                    unless pin_allowed_for_request?(response)
+                      close_with_failure.call('Configured SMC-B PIN violates ST-1506 PIN length request')
+                      next
+                    end
+
+                    pending_pin_notifies += 1
+                    toaster(:info, 'PIN-Anfrage vom ST-1506 erhalten, sende SMC-B PIN ...')
+                    ws.send(request.input_pin_response(response.msg_id, smcb_pin))
+                  elsif response.output_request?
+                    unless authorized_output_request?(response, authorized_slot_id)
+                      close_with_failure.call('ST-1506 output request slot is not authorized for this card')
+                      next
+                    end
+
+                    handle_output_request(ws, response)
+                    close_when_block_done.call
+                  elsif response.cancel?
+                    close_with_failure.call('ST-1506 canceled PIN request')
+                  end
+                end
+
+                ws.on :error do |event|
+                  @result = { success: false, message: event.message }
+                  signal_auth.call(:failed) unless authenticated
+                  debug([:error, event.message])
+                  ws.close
+                end
+
+                ws.on :close do |event|
+                  closed = true
+                  signal_auth.call(:failed) unless authenticated
+                  auth_timeout.cancel if auth_timeout
+                  debug([:close, event.code, event.reason])
+                  ws = nil
+                  EM.stop
+                end
+              end
+            end
+          end
+        end
+
+        begin
+          Timeout.timeout(smcb_total_timeout_seconds + 1) { listener_ready_events.pop }
+          auth_status = Timeout.timeout(smcb_total_timeout_seconds) { auth_events.pop }
+
+          if auth_status == :authenticated
+            block_value = execute_with_rails_executor { yield }
+            block_finished = true
+            schedule_on_eventmachine do
+              if @result[:message].present?
+                close_listener.call
+              else
+                close_when_block_done.call
+              end
+            end
+          end
+        rescue Timeout::Error
+          if listener_ready_signaled
+            @result = { success: false, message: 'Timeout during ST-1506 PIN verification block' } unless @result[:message].present?
+            close_listener.call
+          else
+            @result = { success: false, message: 'Timeout stopping ST-1506 block PIN verification listener' } unless @result[:message].present?
+            listener_thread.kill unless listener_thread.join(1)
+            listener_thread.join(1)
+          end
+        rescue StandardError => e
+          @result = { success: false, message: "ST-1506 PIN verification block failed: #{e.message}" } unless @result[:message].present?
+          close_listener.call
+        ensure
+          unless listener_thread.join(smcb_total_timeout_seconds + 1)
+            @result = { success: false, message: 'Timeout stopping ST-1506 block PIN verification listener' } unless @result[:message].present?
+            close_listener.call
+            listener_thread.kill unless listener_thread.join(1)
+            listener_thread.join(1)
+          end
+        end
+
+        if @result[:success]
+          Result.new(success?: true, message: @result[:message], value: @result[:value])
+        else
+          Result.new(success?: false, message: @result[:message] || 'PIN Verification failed')
+        end
+      end
+
       def handle_output_request(ws, response)
         toaster(:info, response.message) if response.message.present?
         return unless response.expect_response?
 
         code = response.ok_button? ? 'OkButton' : 'Error'
         ws.send(request.output_response(response.msg_id, code))
+      end
+
+      def schedule_on_eventmachine(&block)
+        if EM.reactor_running?
+          EM.schedule(&block)
+        else
+          block.call
+        end
+      end
+
+      def execute_with_rails_executor
+        if defined?(Rails) && Rails.respond_to?(:application) && Rails.application.respond_to?(:executor)
+          Rails.application.executor.wrap { yield }
+        else
+          yield
+        end
       end
 
       def parse_ws_response(data)

--- a/app/services/card_terminals/rmi/cherry_v1/info.rb
+++ b/app/services/card_terminals/rmi/cherry_v1/info.rb
@@ -1,0 +1,232 @@
+module CardTerminals
+  class RMI
+    class CherryV1::Info
+      ATTRIBUTES = %i[
+        terminalname
+        dhcp_enabled
+        macaddr
+        current_ip
+        static_ip
+        dhcp_ip
+        remote_pin_enabled
+        remote_pairing_enabled
+        ntp_enabled
+        ntp_server
+        tftp_server
+        tftp_file
+        firmware_version
+        firmware_builddate
+        serial
+        uptime_total
+        uptime_reboot
+        slot1_plug_cycles
+        slot2_plug_cycles
+        slot3_plug_cycles
+        slot4_plug_cycles
+        identification
+        smckt_iccsn
+        smckt_version
+        smckt_slot
+        smckt_auth1_type
+        smckt_auth1_expiration
+        smckt_auth2_type
+        smckt_auth2_expiration
+        tls_kt_ecgroup
+        tls_kt_pubkey_algo
+        tls_konn_ecgroup
+        tls_konn_pubkey_algo
+      ]
+
+      def initialize(properties)
+        @properties = properties || {}
+      end
+
+      def terminalname
+        properties['deviceName'] || properties[:deviceName]
+      end
+
+      def dhcp_enabled
+        explicit = property('useDhcp')
+        return explicit unless explicit.nil?
+
+        case property('networkMode')
+        when 'Dhcp'
+          true
+        when 'StaticIp', 'Rfc3927'
+          false
+        end
+      end
+
+      def macaddr
+        property('ethernetMacAddress').to_s.delete(':').upcase.presence
+      end
+
+      def current_ip
+        property('ipAddress')
+      end
+
+      def static_ip
+        current_ip if property('networkMode') == 'StaticIp'
+      end
+
+      def dhcp_ip
+        current_ip if dhcp_enabled
+      end
+
+      def remote_pin_enabled
+        %w[remotepin1 remotepin2 remotepin3 remotepin4].any? { |key| property(key).to_i.positive? }
+      end
+
+      def remote_pairing_enabled
+        nil
+      end
+
+      def ntp_enabled
+        property('ntpSyncStatus') == 'synced' || property('ntpSyncServer').present?
+      end
+
+      def ntp_server
+        property('ntpSyncServer')
+      end
+
+      def tftp_server
+        nil
+      end
+
+      def tftp_file
+        nil
+      end
+
+      def firmware_version
+        property('fwVersion')
+      end
+
+      def build_version
+        property('buildVersion')
+      end
+
+      def firmware_builddate
+        nil
+      end
+
+      def serial
+        nil
+      end
+
+      def uptime_total
+        nil
+      end
+
+      def uptime_reboot
+        nil
+      end
+
+      def slot1_plug_cycles
+        nil
+      end
+
+      def slot2_plug_cycles
+        nil
+      end
+
+      def slot3_plug_cycles
+        nil
+      end
+
+      def slot4_plug_cycles
+        nil
+      end
+
+      def identification
+        [property('providerId'), product_code].compact_blank.join('-').presence
+      end
+
+      # ST-1506 exposes smcktSerialNumber, but the protocol field is not a
+      # Cocard ICCSN. Keep it available as a Cherry-specific value instead of
+      # creating/linking an SMC-KT card from an unsupported identifier.
+      def smckt_iccsn
+        nil
+      end
+
+      def smckt_serial_number
+        property('smcktSerialNumber')
+      end
+
+      def smckt_version
+        property('smcktProductTypeVersion')
+      end
+
+      # The ST-1506 device-information payload does not expose an SMC-KT slot.
+      # Return zero so downstream code treats the slot as unavailable.
+      def smckt_slot
+        0
+      end
+
+      # smcktPersonalization documents the SMC-KT personalization algorithms
+      # (for example RSA, ECC, or RSA,ECC), not the same semantics as Cocard's
+      # AUT/AUT2 type fields. Do not overload it into auth*_type.
+      def smckt_personalization
+        property('smcktPersonalization')
+      end
+
+      def smckt_auth1_type
+        nil
+      end
+
+      def smckt_auth1_expiration
+        parse_yyyymmdd(property('smcktExpirationDateAUT'))
+      end
+
+      def smckt_auth2_type
+        nil
+      end
+
+      def smckt_auth2_expiration
+        parse_yyyymmdd(property('smcktExpirationDateAUT2'))
+      end
+
+      def smckt_autd_expiration
+        parse_yyyymmdd(property('smcktExpirationDateAUTD'))
+      end
+
+      def tls_kt_ecgroup
+        nil
+      end
+
+      def tls_kt_pubkey_algo
+        nil
+      end
+
+      def tls_konn_ecgroup
+        nil
+      end
+
+      def tls_konn_pubkey_algo
+        nil
+      end
+
+    private
+      attr_reader :properties
+
+      def product_code
+        property('productShortName').presence || property('productType')
+      end
+
+      def property(key)
+        return properties[key] if properties.key?(key)
+        return properties[key.to_sym] if properties.key?(key.to_sym)
+
+        nil
+      end
+
+      def parse_yyyymmdd(value)
+        value = value.to_s
+        return nil if value.blank?
+
+        Date.strptime(value, '%Y%m%d')
+      rescue ArgumentError
+        nil
+      end
+    end
+  end
+end

--- a/app/services/card_terminals/rmi/cherry_v1/request.rb
+++ b/app/services/card_terminals/rmi/cherry_v1/request.rb
@@ -20,6 +20,10 @@ module CardTerminals
         management_request('SmcbAuthenticationRequest', {})
       end
 
+      def get_device_information
+        management_request('GetDeviceInformationRequest', {})
+      end
+
       def authenticate_response(request_msg_id, response)
         smcb_response('AuthenticateResponse', request_msg_id, Response: response)
       end

--- a/app/services/card_terminals/rmi/cherry_v1/response.rb
+++ b/app/services/card_terminals/rmi/cherry_v1/response.rb
@@ -49,6 +49,14 @@ module CardTerminals
         payload['key'] || payload[:key]
       end
 
+      def device_information
+        get_device_information_response? ? payload : {}
+      end
+
+      def get_device_information_response?
+        payload_type == 'GetDeviceInformationResponse'
+      end
+
       def challenge
         payload['Challenge'] || payload[:Challenge]
       end

--- a/app/services/card_terminals/rmi/creator.rb
+++ b/app/services/card_terminals/rmi/creator.rb
@@ -13,7 +13,7 @@ module CardTerminals
     # * :info  - CardTerminal::RMI::*::Info object
     #
     def initialize(options = {})
-      options.symbolize_keys
+      options = options.symbolize_keys
       @info = options.fetch(:info)
     end
 
@@ -37,13 +37,13 @@ module CardTerminals
         @card_terminal.name = info.terminalname
         @card_terminal.identification = info.identification
         @card_terminal.firmware_version = info.firmware_version
-        @card_terminal.serial = info.serial
-        @card_terminal.uptime_total = info.uptime_total
-        @card_terminal.uptime_reboot = info.uptime_reboot
-        @card_terminal.slot1_plug_cycles = info.slot1_plug_cycles
-        @card_terminal.slot2_plug_cycles = info.slot2_plug_cycles
-        @card_terminal.slot3_plug_cycles = info.slot3_plug_cycles
-        @card_terminal.slot4_plug_cycles = info.slot4_plug_cycles
+        assign_info_attribute(:serial)
+        assign_info_attribute(:uptime_total)
+        assign_info_attribute(:uptime_reboot)
+        assign_info_attribute(:slot1_plug_cycles)
+        assign_info_attribute(:slot2_plug_cycles)
+        assign_info_attribute(:slot3_plug_cycles)
+        assign_info_attribute(:slot4_plug_cycles)
       end
 
       # @card_terminal.last_check = Time.current
@@ -53,7 +53,10 @@ module CardTerminals
       #
       if @card_terminal.save
         @card_terminal.touch
-        update_or_create_card
+        result = update_or_create_card
+        return true if cherry_info? && result.nil?
+
+        result
       else
         Rails.logger.warn("WARN:: could not create or save card terminal #{@card_terminal.mac}: " +
           @card_terminal.errors.full_messages.join('; '))
@@ -64,9 +67,21 @@ module CardTerminals
     private
     attr_reader :info
 
+    def assign_info_attribute(attribute)
+      value = info.public_send(attribute)
+      return if cherry_info? && value.nil?
+
+      @card_terminal.public_send("#{attribute}=", value)
+    end
+
+    def cherry_info?
+      info.is_a?(CardTerminals::RMI::CherryV1::Info)
+    end
+
     def update_or_create_card
       iccsn = info.smckt_iccsn
       return if (iccsn.blank? or iccsn == '-')
+
       expiration = info.smckt_auth2_expiration || info.smckt_auth1_expiration
       card = Card.find_or_create_by(iccsn: iccsn) do |c|
                     c.card_type = 'SMC-KT'

--- a/app/services/cocard/soap/base.rb
+++ b/app/services/cocard/soap/base.rb
@@ -55,9 +55,11 @@ module Cocard::SOAP
                          attributes: soap_operation_attributes,
                          message: soap_message)
       rescue Savon::SOAPFault => error
-        fault = error.to_hash[:fault] || {}
+        fault_hash = error.to_hash
+        fault = (fault_hash[:fault] || fault_hash['fault'] || {}).with_indifferent_access
         details = fault.dig(:detail, :error, :trace)
-                       &.select {|k, v| [:code, :detail].include?(k)}
+                       &.with_indifferent_access
+                       &.select {|k, _v| %w[code detail].include?(k.to_s)}
                        &.map {|k,v| "#{k}: #{v}"}
                        &.join("; ")
         error_messages = [fault[:faultcode], fault[:faultstring], details]

--- a/app/services/cocard/verify_all_pins.rb
+++ b/app/services/cocard/verify_all_pins.rb
@@ -28,8 +28,8 @@ module Cocard
     def call
       error_messages = []
       if card.card_terminal&.pin_mode == 'off'
-        error_messages = "SMC-B Auto-PIN-Mode am Kartenterminal ist off!"
-        toaster(card, :alert, error_message)
+        error_messages = ["SMC-B Auto-PIN-Mode am Kartenterminal ist off!"]
+        toaster(card, :alert, error_messages.join(', '))
         return Result.new(success?: false, error_messages: error_messages)
       end
 
@@ -43,8 +43,26 @@ module Cocard
         message = (card.to_s + "<br/>" + "Kontext: #{card.contexts.first}<br/>ERROR:: " +
                    result.error_messages.join(', ')).html_safe
         toaster(card, status, message)
-      else
+        return Result.new(success?: false, error_messages: result.error_messages)
+      end
 
+      if verify_pin_while_supported?
+        verification_error_messages = []
+        rmi_status = card.card_terminal.rmi.verify_pin_while(card.iccsn) do
+          verification_error_messages = verify_verifiable_contexts
+        end
+        rmi_failed = false
+        rmi_error_messages = []
+        rmi_status.on_failure do |rmi_message|
+          rmi_failed = true
+          rmi_error_messages = Array(rmi_message)
+          toaster(card, :alert, (card.to_s + "<br/>ERROR:: " + rmi_message).html_safe)
+        end
+        return Result.new(success?: false, error_messages: rmi_error_messages) if rmi_failed
+
+        verification_error_messages = Array(rmi_status.value || verification_error_messages)
+        Result.new(success?: verification_error_messages.empty?, error_messages: verification_error_messages)
+      else
         #
         # Background job for auto-enter SMC-B PIN
         #
@@ -52,36 +70,55 @@ module Cocard
         # wait before continue
         sleep 3
 
-        #
-        # Loop over card contexts
-        #
-        card.contexts.where("card_contexts.pin_status = 'VERIFIABLE'")
-                     .where("card_contexts.left_tries = 3").each do |cctx|
-          # just delay for 2 seconds
-          sleep 2
-          # just for debugging
-          # result = Cocard::GetPinStatus.new(card: card, context: cctx).call
-          result = Cocard::VerifyPin.new(card: card, context: cctx).call
-
-          if result.success?
-            status  = :success
-            message = (card.to_s + "<br/>" + "Kontext: #{cctx}<br/>" +
-                       "VERIFY PIN successful").html_safe
-          else
-            status  = :alert
-            message = (card.to_s + "<br/>" + "Kontext: #{cctx}<br/>ERROR:: " +
-                       result.error_messages.join(', ')).html_safe
-
-          end
-          toaster(card, status, message)
-          # update card pin status
-          Cocard::GetPinStatus.new(card: card, context: cctx).call
-        end
+        verification_error_messages = verify_verifiable_contexts
+        Result.new(success?: verification_error_messages.empty?, error_messages: verification_error_messages)
       end
     end
 
   private
     attr_reader :card
+
+    def verify_pin_while_supported?
+      rmi = card.card_terminal&.rmi
+      rmi&.supported? && rmi.available_actions.include?(:verify_pin_while)
+    end
+
+    def verify_verifiable_contexts
+      error_messages = []
+      card.contexts.where("card_contexts.pin_status = 'VERIFIABLE'")
+                   .where("card_contexts.left_tries = 3").each do |cctx|
+        # just delay for 2 seconds
+        sleep 2
+        # just for debugging
+        # result = Cocard::GetPinStatus.new(card: card, context: cctx).call
+        result = verify_pin(cctx)
+
+        if result.success?
+          status  = :success
+          message = (card.to_s + "<br/>" + "Kontext: #{cctx}<br/>" +
+                     "VERIFY PIN successful").html_safe
+        else
+          status  = :alert
+          context_error_messages = Array(result.error_messages)
+          error_messages.concat(context_error_messages)
+          message = (card.to_s + "<br/>" + "Kontext: #{cctx}<br/>ERROR:: " +
+                     context_error_messages.join(', ')).html_safe
+
+        end
+        toaster(card, status, message)
+        # update card pin status
+        Cocard::GetPinStatus.new(card: card, context: cctx).call
+      end
+      error_messages
+    end
+
+    def verify_pin(context)
+      if verify_pin_while_supported?
+        Cocard::VerifyPinWithSt1506Retry.new(card: card, context: context).call
+      else
+        Cocard::VerifyPin.new(card: card, context: context).call
+      end
+    end
 
     def toaster(card, status, message)
       message = "#{card.name}: #{message}"

--- a/app/services/cocard/verify_pin_with_st1506_retry.rb
+++ b/app/services/cocard/verify_pin_with_st1506_retry.rb
@@ -1,0 +1,49 @@
+module Cocard
+  # Retry connector VerifyPin only for the ST1506 coordinated flow when the
+  # connector reports resource reservation (trace code 4060).
+  class VerifyPinWithSt1506Retry
+    DEFAULT_RETRIES = 2
+    DEFAULT_DELAY = 3.seconds
+    RESOURCE_RESERVATION_CODE = '4060'
+    RESOURCE_RESERVATION_TEXT = /resource.?reservation|ressourcenreservierung|reservier|ressource[n]?\s+belegt/i
+
+    def initialize(options = {})
+      options = options.symbolize_keys
+      @card = options.fetch(:card)
+      @context = options.fetch(:context)
+      @retries = options.fetch(:retries, DEFAULT_RETRIES)
+      @delay = options.fetch(:delay, DEFAULT_DELAY)
+    end
+
+    def call
+      attempts = 0
+
+      loop do
+        result = Cocard::VerifyPin.new(card: card, context: context).call
+        return result unless retryable_resource_reservation?(result)
+        return result if attempts >= retries
+
+        attempts += 1
+        sleep delay
+      end
+    end
+
+  private
+    attr_reader :card, :context, :retries, :delay
+
+    def retryable_resource_reservation?(result)
+      return false if result.blank? || result.success?
+
+      pin_verify = result.respond_to?(:pin_verify) ? result.pin_verify : nil
+      error_code = pin_verify.respond_to?(:error_code) ? pin_verify.error_code.to_s : nil
+      return true if error_code == RESOURCE_RESERVATION_CODE
+
+      messages = Array(result.respond_to?(:error_messages) ? result.error_messages : nil)
+      messages << pin_verify.error_text if pin_verify.respond_to?(:error_text)
+      messages.compact.any? do |message|
+        text = message.to_s
+        text.include?(RESOURCE_RESERVATION_CODE) || text.match?(RESOURCE_RESERVATION_TEXT)
+      end
+    end
+  end
+end

--- a/spec/models/cocard/pin_verify_spec.rb
+++ b/spec/models/cocard/pin_verify_spec.rb
@@ -41,13 +41,31 @@ module Cocard
     describe "with real pin status" do
       it { expect(subject.pin_result).to eq("ERROR") }
       it { expect(subject.status).to eq("Warning") }
+      it { expect(subject.error_code).to eq("4043") }
       it { expect(subject.error_text).to eq("Timeout bei der PIN-Eingabe") }
       it { expect(subject.left_tries).to eq(nil) }
     end
 
+    it "reads trace values from string-keyed hashes too" do
+      string_hash = {
+        'status' => {
+          'error' => {
+            'trace' => {
+              'code' => '4060',
+              'error_text' => 'Ressource belegt'
+            }
+          }
+        }
+      }
+      pin_verify = Cocard::PinVerify.new(string_hash)
+
+      expect(pin_verify.error_code).to eq('4060')
+      expect(pin_verify.error_text).to eq('Ressource belegt')
+    end
+
     describe "Cocard::PinVerify::ATTRIBUTES" do
       it { expect(Cocard::PinVerify::ATTRIBUTES).to contain_exactly(
-             :pin_result, :status, :error_text, :left_tries ) }
+             :pin_result, :status, :error_code, :error_text, :left_tries ) }
     end
   end
 end

--- a/spec/requests/cards_spec.rb
+++ b/spec/requests/cards_spec.rb
@@ -194,6 +194,38 @@ RSpec.describe "/cards", type: :request do
     end
   end
 
+  describe "POST /verify_pin" do
+    let(:card) do
+      FactoryBot.create(:card,
+        card_terminal_slot: cts,
+        card_handle: 'card-handle-1',
+        card_type: 'SMC-B'
+      )
+    end
+    let(:rmi) { instance_double(CardTerminals::RMI, supported?: true, available_actions: [:verify_pin_while]) }
+    let(:verify_result) { Cocard::VerifyPin::Result.new(success?: true, error_messages: [], pin_verify: nil) }
+
+    before do
+      card.contexts << context
+      allow_any_instance_of(CardTerminal).to receive(:rmi).and_return(rmi)
+    end
+
+    it "uses the ST1506 retry helper inside verify_pin_while" do
+      helper = instance_double(Cocard::VerifyPinWithSt1506Retry, call: verify_result)
+      expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+        value = block.call
+        CardTerminals::RMI::Status.success('ok', value)
+      end
+      expect(Cocard::VerifyPinWithSt1506Retry).to receive(:new)
+        .with(card: card, context: context).once.and_return(helper)
+      expect(Cocard::VerifyPin).not_to receive(:new)
+
+      post verify_pin_card_url(card, context_id: context.id)
+
+      expect(response).to be_successful
+    end
+  end
+
   describe "DELETE /destroy" do
     it "soft_deletes the requested card" do
       card = Card.create! valid_attributes

--- a/spec/services/card_terminals/rmi/cherry_v1_spec.rb
+++ b/spec/services/card_terminals/rmi/cherry_v1_spec.rb
@@ -101,10 +101,10 @@ module CardTerminals
       end
 
       describe '#available_actions' do
-        it 'includes get_info while preserving verify_pin' do
+        it 'includes get_info and Cherry block verification while preserving verify_pin' do
           card_terminal = FactoryBot.create(:card_terminal, :with_mac, ip: '192.0.2.10')
 
-          expect(described_class.new(card_terminal: card_terminal).available_actions).to contain_exactly(:verify_pin, :get_info)
+          expect(described_class.new(card_terminal: card_terminal).available_actions).to contain_exactly(:verify_pin, :verify_pin_while, :get_info)
         end
       end
 
@@ -669,6 +669,45 @@ module CardTerminals
         end
       end
 
+      describe '#verify_pin_while' do
+        let(:card_terminal) { FactoryBot.create(:card_terminal, :with_mac, ip: '192.0.2.10') }
+        let(:service) { described_class.new(card_terminal: card_terminal) }
+        let(:key_result) { described_class::Result.new(success?: true, message: 'key', value: 'a' * 64) }
+
+        before do
+          allow(card_terminal).to receive(:rmi_port).and_return(8443)
+          allow(card_terminal).to receive(:tcp_port_open?).with(8443).and_return(true)
+        end
+
+        it 'validates the card slot and SMC-B key before starting the block listener' do
+          slot = FactoryBot.create(:card_terminal_slot, card_terminal: card_terminal, slotid: 2)
+          FactoryBot.create(:card, iccsn: '802760000000000004', card_terminal_slot: slot)
+          block_called = false
+
+          with_env('DEFAULT_SMCB_PIN' => '123456', 'DEFAULT_WS_AUTH_PASS' => 'secret') do
+            expect(service).to receive(:fetch_smcb_authentication_key).and_return(key_result)
+            expect(service).to receive(:connect_remote_smcb_api_while).with('a' * 64, 2).and_return(described_class::Result.new(success?: true, message: 'ok'))
+
+            result = service.verify_pin_while('802760000000000004') { block_called = true }
+
+            expect(result).to be_success
+            expect(block_called).to be(false)
+          end
+        end
+
+        it 'fails before fetching an SMC-B key when the ICCSN does not belong to this terminal' do
+          with_env('DEFAULT_SMCB_PIN' => '123456', 'DEFAULT_WS_AUTH_PASS' => 'secret') do
+            expect(service).not_to receive(:fetch_smcb_authentication_key)
+            expect(service).not_to receive(:connect_remote_smcb_api_while)
+
+            result = service.verify_pin_while('802760000000000099') { raise 'should not run' }
+
+            expect(result).not_to be_success
+            expect(result.message).to match(/not assigned|ICCSN/)
+          end
+        end
+      end
+
       describe '#connect_remote_smcb_api' do
         let(:card_terminal) { instance_double(CardTerminal, id: 1, ip: '192.0.2.10', rmi_port: 8443) }
         let(:service) { described_class.new(card_terminal: card_terminal) }
@@ -819,6 +858,367 @@ module CardTerminals
 
           def emit_message(data)
             handlers.fetch(:message).call(OpenStruct.new(data: data))
+          end
+        end
+      end
+
+      describe '#connect_remote_smcb_api_while' do
+        let(:card_terminal) { instance_double(CardTerminal, id: 1, ip: '192.0.2.10', rmi_port: 8443) }
+        let(:service) { described_class.new(card_terminal: card_terminal) }
+        let(:websocket) { FakeBlockWebSocket.new }
+        let(:key) { 'a' * 64 }
+        let(:timer) { instance_double(EM::Timer, cancel: true) }
+
+        before do
+          allow(Faye::WebSocket::Client).to receive(:new).and_return(websocket)
+          allow(EM::Timer).to receive(:new) do |_seconds, &block|
+            @timeout_callback = block
+            timer
+          end
+          allow(EM).to receive(:stop)
+          allow(EM).to receive(:reactor_running?).and_return(false)
+          allow(EM).to receive(:run) do |&block|
+            block.call
+            @exercise_websocket.call
+          end
+          allow(service).to receive(:toaster)
+        end
+
+        it 'runs the caller block only after SMC-B authentication, answers multiple authorized PIN requests, and returns the block value' do
+          block_started = Queue.new
+          release_block = Queue.new
+          events = []
+
+          @exercise_websocket = lambda do
+            expect(events).to be_empty
+            websocket.emit_message(authenticate_request)
+            expect(Timeout.timeout(1) { block_started.pop }).to eq(:started)
+            expect(websocket.sent_payload_types).to include('AuthenticateResponse')
+
+            websocket.emit_message(input_pin_request('pin-1', 'Slot1'))
+            websocket.emit_message(success_notify('notify-1'))
+            websocket.emit_message(input_pin_request('pin-2', 'Slot1'))
+            websocket.emit_message(success_notify('notify-2'))
+            release_block << true
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) do
+              events << :block
+              block_started << :started
+              release_block.pop
+              :block_result
+            end
+          end
+
+          expect(events).to eq([:block])
+          expect(websocket.sent_payload_types.count('InputPinResponse')).to eq(2)
+          expect(websocket.close_count).to eq(1)
+          expect(result).to be_success
+          expect(result.value).to eq(:block_result)
+        end
+
+        it 'keeps the listener open after the block until pending PIN notify confirmations arrive' do
+          block_started = Queue.new
+          release_block = Queue.new
+
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            Timeout.timeout(1) { block_started.pop }
+            websocket.emit_message(input_pin_request('pin-1', 'Slot1'))
+            release_block << true
+            sleep 0.05
+            expect(websocket.close_count).to eq(0)
+
+            websocket.emit_message(success_notify('notify-1'))
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) do
+              block_started << true
+              release_block.pop
+            end
+          end
+
+          expect(websocket.close_count).to eq(1)
+          expect(result).to be_success
+        end
+
+        it 'rejects wrong-slot PIN requests and closes without sending the PIN' do
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            websocket.emit_message(input_pin_request('pin-1', 'Slot2'))
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { sleep 0.01 }
+          end
+
+          expect(websocket.sent_payload_types).not_to include('InputPinResponse')
+          expect(websocket.close_count).to eq(1)
+          expect(result).not_to be_success
+          expect(result.message).to match(/not authorized/)
+        end
+
+        it 'waits for the caller block to finish before returning after a wrong-slot failure' do
+          block_started = Queue.new
+          release_block = Queue.new
+          block_finished = Queue.new
+          returned = Queue.new
+
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            Timeout.timeout(1) { block_started.pop }
+            websocket.emit_message(input_pin_request('pin-1', 'Slot2'))
+          end
+
+          thread = Thread.new do
+            result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+              service.send(:connect_remote_smcb_api_while, key, 1) do
+                block_started << true
+                release_block.pop
+                block_finished << true
+              end
+            end
+            returned << result
+            result
+          end
+
+          sleep 0.2
+          expect(returned).to be_empty
+
+          release_block << true
+          result = Timeout.timeout(1) { returned.pop }
+
+          expect(Timeout.timeout(1) { block_finished.pop }).to be(true)
+          expect(result).not_to be_success
+          expect(result.message).to match(/not authorized/)
+          expect(thread.value).to eq(result)
+        ensure
+          release_block << true if defined?(release_block)
+          thread&.join(1)
+        end
+
+        it 'fails without running the caller block when the auth timer fires before authentication' do
+          @exercise_websocket = lambda do
+            @timeout_callback.call
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { raise 'should not run' }
+          end
+
+          expect(result).not_to be_success
+          expect(result.message).to eq('Timeout during ST-1506 block PIN verification')
+        end
+
+        it 'preserves a pre-auth timeout result when listener shutdown join times out' do
+          allow(service).to receive(:smcb_total_timeout_seconds).and_return(0.01)
+          join_calls = 0
+          allow(Thread).to receive(:new).and_wrap_original do |original, *args, &thread_block|
+            thread = original.call(*args, &thread_block)
+            allow(thread).to receive(:join) do |_timeout = nil|
+              join_calls += 1
+              join_calls == 1 ? nil : true
+            end
+            allow(thread).to receive(:kill).and_return(thread)
+            thread
+          end
+
+          @exercise_websocket = lambda do
+            @timeout_callback.call
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { raise 'should not run' }
+          end
+
+          expect(result).not_to be_success
+          expect(result.message).to eq('Timeout during ST-1506 block PIN verification')
+        end
+
+        it 'does not spend the auth timeout while waiting for the EventMachine lock' do
+          allow(service).to receive(:smcb_total_timeout_seconds).and_return(0.02)
+          allow(described_class).to receive(:with_eventmachine_lock) do |&block|
+            expect(Faye::WebSocket::Client).not_to have_received(:new)
+            sleep 0.06
+            block.call
+          end
+
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { :after_auth }
+          end
+
+          expect(Faye::WebSocket::Client).to have_received(:new).once
+          expect(websocket.close_count).to eq(1)
+          expect(result).to be_success
+          expect(result.value).to eq(:after_auth)
+        end
+
+        it 'does not stop another active reactor when startup times out before this listener starts' do
+          blocked_listener = Queue.new
+
+          allow(service).to receive(:smcb_total_timeout_seconds).and_return(0.01)
+          allow(EM).to receive(:reactor_running?).and_return(true)
+          expect(EM).not_to receive(:schedule)
+          expect(EM).not_to receive(:stop)
+          expect(Faye::WebSocket::Client).not_to receive(:new)
+          allow(described_class).to receive(:with_eventmachine_lock) do
+            blocked_listener.pop
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { raise 'should not run' }
+          end
+
+          expect(websocket.close_count).to eq(0)
+          expect(result).not_to be_success
+          expect(result.message).to eq('Timeout stopping ST-1506 block PIN verification listener')
+        ensure
+          blocked_listener << true if defined?(blocked_listener)
+        end
+
+        it 'ignores the auth timer after authentication while a slow caller block is running' do
+          block_started = Queue.new
+          block_finished = Queue.new
+
+          allow(service).to receive(:smcb_total_timeout_seconds).and_return(0.01)
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            Timeout.timeout(1) { block_started.pop }
+            @timeout_callback.call
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) do
+              block_started << true
+              sleep 0.05
+              block_finished << true
+              :slow_block_result
+            end
+          end
+
+          expect(timer).to have_received(:cancel)
+          expect(Timeout.timeout(1) { block_finished.pop }).to be(true)
+          expect(websocket.close_count).to eq(1)
+          expect(result).to be_success
+          expect(result.value).to eq(:slow_block_result)
+        end
+
+        it 'runs listener thread callbacks and the caller block through the Rails executor' do
+          block_started = Queue.new
+          release_block = Queue.new
+          listener_callback_wrapped = Queue.new
+          caller_wrapped = Queue.new
+          executor = Class.new do
+            def wrap
+              previous = Thread.current[:cherry_v1_executor_wrapped]
+              Thread.current[:cherry_v1_executor_wrapped] = true
+              yield
+            ensure
+              Thread.current[:cherry_v1_executor_wrapped] = previous
+            end
+          end.new
+
+          allow(Rails).to receive(:application).and_return(double('Rails application', executor: executor))
+          expect(service).to receive(:toaster) do
+            listener_callback_wrapped << Thread.current[:cherry_v1_executor_wrapped]
+          end
+
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            Timeout.timeout(1) { block_started.pop }
+            websocket.emit_message(input_pin_request('pin-1', 'Slot1'))
+            websocket.emit_message(success_notify('notify-1'))
+            release_block << true
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) do
+              caller_wrapped << Thread.current[:cherry_v1_executor_wrapped]
+              block_started << true
+              release_block.pop
+              :executor_wrapped
+            end
+          end
+
+          expect(Timeout.timeout(1) { listener_callback_wrapped.pop }).to be(true)
+          expect(Timeout.timeout(1) { caller_wrapped.pop }).to be(true)
+          expect(result).to be_success
+          expect(result.value).to eq(:executor_wrapped)
+        end
+
+        it 'converts block errors to a failure and closes the listener' do
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            sleep 0.05
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { raise 'connector failed' }
+          end
+
+          expect(websocket.close_count).to eq(1)
+          expect(result).not_to be_success
+          expect(result.message).to match(/connector failed/)
+        end
+
+        def authenticate_request
+          {
+            'PayloadType' => 'AuthenticateRequest',
+            'Header' => { 'MsgId' => 'auth-1', 'SessionId' => 'session-1' },
+            'Payload' => { 'ApiVersion' => '1.0', 'Challenge' => 'b' * 64 }
+          }.to_json
+        end
+
+        def input_pin_request(msg_id, slot)
+          {
+            'PayloadType' => 'InputPinRequest',
+            'Header' => { 'MsgId' => msg_id, 'SessionId' => 'session-1' },
+            'Payload' => { 'Slot' => slot, 'MinLen' => 6, 'MaxLen' => 8 }
+          }.to_json
+        end
+
+        def success_notify(msg_id)
+          {
+            'PayloadType' => 'Notify',
+            'Header' => { 'MsgId' => msg_id, 'SessionId' => 'session-1' },
+            'Payload' => { 'Code' => 0 }
+          }.to_json
+        end
+
+        class FakeBlockWebSocket
+          attr_reader :close_count, :handlers, :sent
+
+          def initialize
+            @close_count = 0
+            @handlers = {}
+            @sent = []
+          end
+
+          def on(event, &block)
+            handlers[event] = block
+          end
+
+          def send(message)
+            sent << message
+          end
+
+          def close
+            @close_count += 1
+            handlers[:close]&.call(OpenStruct.new(code: 1000, reason: 'closed'))
+          end
+
+          def emit_message(data)
+            handlers.fetch(:message).call(OpenStruct.new(data: data))
+          end
+
+          def sent_payload_types
+            sent.map { |message| JSON.parse(message)['PayloadType'] }
           end
         end
       end

--- a/spec/services/card_terminals/rmi/cherry_v1_spec.rb
+++ b/spec/services/card_terminals/rmi/cherry_v1_spec.rb
@@ -55,6 +55,15 @@ module CardTerminals
           expect(json['Header']).to include('MsgId', 'InReplyToId' => 'request-id', 'SessionId' => 'smcb-session')
           expect(json['Payload']).to eq('Code' => 'Pin', 'Pin' => '123456')
         end
+
+        it 'builds a GetDeviceInformationRequest with an empty payload and management session id' do
+          session = { management_session_id: 'management-session' }
+          json = JSON.parse(described_class.new(session).get_device_information)
+
+          expect(json).to include('payloadType' => 'GetDeviceInformationRequest')
+          expect(json['header']).to include('msgId', 'sessionId' => 'management-session')
+          expect(json['payload']).to eq({})
+        end
       end
 
       describe CherryV1::Response do
@@ -75,8 +84,27 @@ module CardTerminals
           expect(response_for('header' => { 'SessionId' => 'legacy-header-session' }).session_id).to eq('legacy-header-session')
         end
 
+        it 'exposes GetDeviceInformationResponse payload without breaking other response parsing' do
+          response = response_for(
+            'payloadType' => 'GetDeviceInformationResponse',
+            'payload' => { 'deviceName' => 'Cherry', 'ipAddress' => '192.0.2.10' }
+          )
+
+          expect(response).to be_get_device_information_response
+          expect(response.device_information).to eq('deviceName' => 'Cherry', 'ipAddress' => '192.0.2.10')
+          expect(response_for('PayloadType' => 'InputPinRequest', 'Payload' => { 'Slot' => 'Slot3' }).slot).to eq('Slot3')
+        end
+
         def response_for(message)
           described_class.new(message.to_json)
+        end
+      end
+
+      describe '#available_actions' do
+        it 'includes get_info while preserving verify_pin' do
+          card_terminal = FactoryBot.create(:card_terminal, :with_mac, ip: '192.0.2.10')
+
+          expect(described_class.new(card_terminal: card_terminal).available_actions).to contain_exactly(:verify_pin, :get_info)
         end
       end
 
@@ -85,6 +113,395 @@ module CardTerminals
           card_terminal = FactoryBot.create(:card_terminal, :with_mac, ip: '192.0.2.10')
 
           expect(described_class.new(card_terminal: card_terminal).rmi_port).to eq(443)
+        end
+      end
+
+      describe CherryV1::Info do
+        let(:payload) do
+          {
+            'providerId' => 'DECHY',
+            'productShortName' => 'ST1506',
+            'deviceName' => 'Cherry ST-1506',
+            'ethernetMacAddress' => 'aa:bb:cc:dd:ee:ff',
+            'ipAddress' => '192.0.2.10',
+            'useDhcp' => true,
+            'networkMode' => 'Dhcp',
+            'fwVersion' => '3.2.1',
+            'buildVersion' => 'build-42',
+            'remotepin1' => 0,
+            'remotepin2' => 1,
+            'ntpSyncServer' => '192.0.2.53',
+            'smcktProductTypeVersion' => '2.0',
+            'smcktSerialNumber' => 'CHERRY-SERIAL-123',
+            'smcktPersonalization' => 'RSA,ECC',
+            'smcktExpirationDateAUT' => '20270131',
+            'smcktExpirationDateAUT2' => '20280229',
+            'smcktExpirationDateAUTD' => 'invalid'
+          }
+        end
+
+        it 'maps Cherry device information to the common info interface conservatively' do
+          info = described_class.new(payload)
+
+          expect(info.terminalname).to eq('Cherry ST-1506')
+          expect(info.identification).to eq('DECHY-ST1506')
+          expect(info.macaddr).to eq('AABBCCDDEEFF')
+          expect(info.current_ip).to eq('192.0.2.10')
+          expect(info.dhcp_enabled).to be(true)
+          expect(info.dhcp_ip).to eq('192.0.2.10')
+          expect(info.static_ip).to be_nil
+          expect(info.remote_pin_enabled).to be(true)
+          expect(info.ntp_enabled).to be(true)
+          expect(info.ntp_server).to eq('192.0.2.53')
+          expect(info.firmware_version).to eq('3.2.1')
+          expect(info.build_version).to eq('build-42')
+          expect(info.smckt_version).to eq('2.0')
+          expect(info.smckt_iccsn).to be_nil
+          expect(info.smckt_serial_number).to eq('CHERRY-SERIAL-123')
+          expect(info.smckt_slot).to eq(0)
+          expect(info.smckt_personalization).to eq('RSA,ECC')
+          expect(info.smckt_auth1_type).to be_nil
+          expect(info.smckt_auth1_expiration).to eq(Date.new(2027, 1, 31))
+          expect(info.smckt_auth2_type).to be_nil
+          expect(info.smckt_auth2_expiration).to eq(Date.new(2028, 2, 29))
+          expect(info.smckt_autd_expiration).to be_nil
+        end
+
+        it 'derives DHCP from networkMode and returns nil/safe defaults for unavailable attributes' do
+          info = described_class.new('networkMode' => 'StaticIp', 'ipAddress' => '192.0.2.20')
+
+          expect(info.dhcp_enabled).to be(false)
+          expect(info.static_ip).to eq('192.0.2.20')
+          expect(info.dhcp_ip).to be_nil
+          expect(info.macaddr).to be_nil
+          expect(info.serial).to be_nil
+          expect(info.uptime_total).to be_nil
+          expect(info.slot1_plug_cycles).to be_nil
+          expect(info.remote_pairing_enabled).to be_nil
+          expect(info.tls_kt_ecgroup).to be_nil
+        end
+
+        it 'keeps SMC-KT personalization conservative for supported protocol values' do
+          %w[RSA ECC RSA,ECC].each do |personalization|
+            info = described_class.new('smcktPersonalization' => personalization)
+
+            expect(info.smckt_personalization).to eq(personalization)
+            expect(info.smckt_auth1_type).to be_nil
+            expect(info.smckt_auth2_type).to be_nil
+          end
+        end
+      end
+
+      describe '#get_info' do
+        let(:card_terminal) { instance_double(CardTerminal, id: 1, ip: '192.0.2.10', rmi_port: 8443) }
+        let(:service) { described_class.new(card_terminal: card_terminal) }
+        let(:websocket) { FakeManagementWebSocket.new }
+        let(:timer) { instance_double(EM::Timer, cancel: true) }
+
+        before do
+          allow(card_terminal).to receive(:tcp_port_open?).with(8443).and_return(true)
+          allow(Faye::WebSocket::Client).to receive(:new).and_return(websocket)
+          allow(EM::Timer).to receive(:new).and_return(timer)
+          allow(EM).to receive(:stop)
+          allow(EM).to receive(:run) do |&block|
+            block.call
+            websocket.emit_open
+          end
+        end
+
+        it 'validates websocket credentials before opening the management websocket' do
+          with_env('DEFAULT_WS_AUTH_PASS' => nil) do
+            expect(Faye::WebSocket::Client).not_to receive(:new)
+
+            result = service.get_info
+
+            expect(result).not_to be_success
+            expect(result.message).to match(/DEFAULT_WS_AUTH_PASS/)
+          end
+        end
+
+        it 'logs in, requests device information, logs out, and returns Cherry info' do
+          websocket.on_send('LoginRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'login-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'LoginResponse',
+              'payload' => { 'sessionId' => 'management-session' }
+            )
+          end
+          websocket.on_send('GetDeviceInformationRequest') do |request|
+            expect(request.dig('header', 'sessionId')).to eq('management-session')
+            websocket.emit_message(
+              'header' => { 'msgId' => 'info-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'GetDeviceInformationResponse',
+              'payload' => { 'providerId' => 'DECHY', 'productShortName' => 'ST1506', 'deviceName' => 'Cherry' }
+            )
+          end
+          websocket.on_send('LogoutRequest') { websocket.close }
+
+          result = with_env('DEFAULT_WS_AUTH_PASS' => 'secret') { service.get_info }
+
+          expect(result).to be_success
+          expect(result.message).to eq('Device information received')
+          expect(result.value).to be_a(CherryV1::Info)
+          expect(result.value.identification).to eq('DECHY-ST1506')
+          expect(websocket.sent_payload_types).to eq(%w[LoginRequest GetDeviceInformationRequest LogoutRequest])
+        end
+
+        it 'preserves successful device information when cleanup logout response has no inReplyToId' do
+          websocket.on_send('LoginRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'login-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'LoginResponse',
+              'payload' => { 'sessionId' => 'management-session' }
+            )
+          end
+          websocket.on_send('GetDeviceInformationRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'info-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'GetDeviceInformationResponse',
+              'payload' => { 'providerId' => 'DECHY', 'productShortName' => 'ST1506', 'deviceName' => 'Cherry' }
+            )
+          end
+          websocket.on_send('LogoutRequest') do
+            websocket.emit_message(
+              'header' => { 'msgId' => 'logout-response' },
+              'payloadType' => 'LogoutResponse',
+              'payload' => {}
+            )
+          end
+
+          result = with_env('DEFAULT_WS_AUTH_PASS' => 'secret') { service.get_info }
+
+          expect(result).to be_success
+          expect(result.message).to eq('Device information received')
+          expect(result.value).to be_a(CherryV1::Info)
+          expect(result.value.identification).to eq('DECHY-ST1506')
+          expect(websocket.sent_payload_types).to eq(%w[LoginRequest GetDeviceInformationRequest LogoutRequest])
+          expect(websocket.close_count).to eq(1)
+        end
+
+        it 'preserves successful device information when cleanup logout JSON is malformed' do
+          websocket.on_send('LoginRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'login-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'LoginResponse',
+              'payload' => { 'sessionId' => 'management-session' }
+            )
+          end
+          websocket.on_send('GetDeviceInformationRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'info-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'GetDeviceInformationResponse',
+              'payload' => { 'providerId' => 'DECHY', 'productShortName' => 'ST1506', 'deviceName' => 'Cherry' }
+            )
+          end
+          websocket.on_send('LogoutRequest') { websocket.emit_raw('{not-json') }
+
+          result = with_env('DEFAULT_WS_AUTH_PASS' => 'secret') { service.get_info }
+
+          expect(result).to be_success
+          expect(result.message).to eq('Device information received')
+          expect(result.value).to be_a(CherryV1::Info)
+          expect(result.value.identification).to eq('DECHY-ST1506')
+          expect(websocket.sent_payload_types).to eq(%w[LoginRequest GetDeviceInformationRequest LogoutRequest])
+          expect(websocket.close_count).to eq(1)
+        end
+
+        it 'fails fast when a LoginRequest receives a successful non-login payload with a session id' do
+          websocket.on_send('LoginRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'unexpected-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'GetDeviceInformationResponse',
+              'payload' => { 'sessionId' => 'management-session', 'deviceName' => 'Cherry' }
+            )
+          end
+          websocket.on_send('GetDeviceInformationRequest') { raise 'unexpected GetDeviceInformationRequest' }
+
+          result = with_env('DEFAULT_WS_AUTH_PASS' => 'secret') { service.get_info }
+
+          expect(result).not_to be_success
+          expect(result.message).to eq('Unexpected ST-1506 management response for LoginRequest: GetDeviceInformationResponse')
+          expect(websocket.sent_payload_types).to eq(%w[LoginRequest])
+          expect(websocket.close_count).to eq(1)
+        end
+
+        it 'logs out best-effort after a post-login device-information error' do
+          websocket.on_send('LoginRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'login-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'LoginResponse',
+              'payload' => { 'sessionId' => 'management-session' }
+            )
+          end
+          websocket.on_send('GetDeviceInformationRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'info-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'GetDeviceInformationResponse',
+              'payload' => { 'error' => 'Internal error' }
+            )
+          end
+          websocket.on_send('LogoutRequest') { websocket.close }
+
+          result = with_env('DEFAULT_WS_AUTH_PASS' => 'secret') { service.get_info }
+
+          expect(result).not_to be_success
+          expect(result.message).to eq('Internal error')
+          expect(websocket.sent_payload_types).to eq(%w[LoginRequest GetDeviceInformationRequest LogoutRequest])
+          expect(websocket.close_count).to eq(1)
+        end
+
+        it 'fails fast and closes on a successful response with missing inReplyToId before login' do
+          websocket.on_send('LoginRequest') do
+            websocket.emit_message(
+              'header' => { 'msgId' => 'login-response' },
+              'payloadType' => 'LoginResponse',
+              'payload' => { 'sessionId' => 'management-session' }
+            )
+          end
+
+          result = with_env('DEFAULT_WS_AUTH_PASS' => 'secret') { service.get_info }
+
+          expect(result).not_to be_success
+          expect(result.message).to match(/unknown inReplyToId \(missing\)/)
+          expect(websocket.sent_payload_types).to eq(%w[LoginRequest])
+          expect(websocket.close_count).to eq(1)
+        end
+
+        it 'preserves a post-login protocol failure message when logout hangs until timeout' do
+          allow(EM::Timer).to receive(:new) do |_seconds, &block|
+            @timer_callback = block
+            timer
+          end
+          websocket.on_send('LoginRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'login-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'LoginResponse',
+              'payload' => { 'sessionId' => 'management-session' }
+            )
+          end
+          websocket.on_send('GetDeviceInformationRequest') do
+            websocket.emit_message(
+              'header' => { 'msgId' => 'info-response', 'inReplyToId' => 'unknown-request-id' },
+              'payloadType' => 'GetDeviceInformationResponse',
+              'payload' => { 'deviceName' => 'Cherry' }
+            )
+          end
+          websocket.on_send('LogoutRequest') { @timer_callback.call }
+
+          result = with_env('DEFAULT_WS_AUTH_PASS' => 'secret') { service.get_info }
+
+          expect(result).not_to be_success
+          expect(result.message).to match(/unknown inReplyToId unknown-request-id/)
+          expect(result.message).not_to eq('Timeout while requesting device information')
+          expect(websocket.sent_payload_types).to eq(%w[LoginRequest GetDeviceInformationRequest LogoutRequest])
+          expect(websocket.close_count).to eq(1)
+        end
+
+        it 'fails fast and logs out after login on a successful response with unknown inReplyToId' do
+          websocket.on_send('LoginRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'login-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'LoginResponse',
+              'payload' => { 'sessionId' => 'management-session' }
+            )
+          end
+          websocket.on_send('GetDeviceInformationRequest') do
+            websocket.emit_message(
+              'header' => { 'msgId' => 'info-response', 'inReplyToId' => 'unknown-request-id' },
+              'payloadType' => 'GetDeviceInformationResponse',
+              'payload' => { 'deviceName' => 'Cherry' }
+            )
+          end
+          websocket.on_send('LogoutRequest') { websocket.close }
+
+          result = with_env('DEFAULT_WS_AUTH_PASS' => 'secret') { service.get_info }
+
+          expect(result).not_to be_success
+          expect(result.message).to match(/unknown inReplyToId unknown-request-id/)
+          expect(websocket.sent_payload_types).to eq(%w[LoginRequest GetDeviceInformationRequest LogoutRequest])
+          expect(websocket.close_count).to eq(1)
+        end
+
+        it 'fails fast and logs out on an unexpected successful payload for the pending request' do
+          websocket.on_send('LoginRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'login-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'LoginResponse',
+              'payload' => { 'sessionId' => 'management-session' }
+            )
+          end
+          websocket.on_send('GetDeviceInformationRequest') do |request|
+            websocket.emit_message(
+              'header' => { 'msgId' => 'unexpected-response', 'inReplyToId' => request.dig('header', 'msgId') },
+              'payloadType' => 'LoginResponse',
+              'payload' => { 'sessionId' => 'other-session' }
+            )
+          end
+          websocket.on_send('LogoutRequest') { websocket.close }
+
+          result = with_env('DEFAULT_WS_AUTH_PASS' => 'secret') { service.get_info }
+
+          expect(result).not_to be_success
+          expect(result.message).to eq('Unexpected ST-1506 management response for GetDeviceInformationRequest: LoginResponse')
+          expect(websocket.sent_payload_types).to eq(%w[LoginRequest GetDeviceInformationRequest LogoutRequest])
+          expect(websocket.close_count).to eq(1)
+        end
+
+        it 'fails and closes on malformed management JSON' do
+          websocket.on_send('LoginRequest') { websocket.emit_raw('{not-json') }
+
+          result = with_env('DEFAULT_WS_AUTH_PASS' => 'secret') { service.get_info }
+
+          expect(result).not_to be_success
+          expect(result.message).to match(/Invalid JSON from ST-1506/)
+          expect(websocket.sent_payload_types).to eq(%w[LoginRequest])
+          expect(websocket.close_count).to eq(1)
+        end
+
+        class FakeManagementWebSocket
+          attr_reader :close_count, :handlers, :sent
+
+          def initialize
+            @close_count = 0
+            @handlers = {}
+            @sent = []
+            @send_handlers = {}
+          end
+
+          def on(event, &block)
+            handlers[event] = block
+          end
+
+          def send(message)
+            request = JSON.parse(message)
+            sent << request
+            @send_handlers.fetch(request['payloadType']).call(request)
+          end
+
+          def close
+            @close_count += 1
+            handlers[:close]&.call(OpenStruct.new(code: 1000, reason: 'closed'))
+          end
+
+          def emit_open
+            handlers.fetch(:open).call(OpenStruct.new)
+          end
+
+          def emit_message(message)
+            emit_raw(message.to_json)
+          end
+
+          def emit_raw(data)
+            handlers.fetch(:message).call(OpenStruct.new(data: data))
+          end
+
+          def on_send(payload_type, &block)
+            @send_handlers[payload_type] = block
+          end
+
+          def sent_payload_types
+            sent.map { |request| request['payloadType'] }
+          end
         end
       end
 
@@ -156,6 +573,35 @@ module CardTerminals
           stub_const('CardTerminals::RMI::CherryV1::TERMINAL_MUTEXES', {})
           stub_const('CardTerminals::RMI::CherryV1::TERMINAL_MUTEXES_MUTEX', Mutex.new)
 
+          instrumented_mutex = Class.new do
+            attr_reader :waiting_for_lock
+
+            def initialize
+              @mutex = Mutex.new
+              @state_mutex = Mutex.new
+              @locked = false
+              @waiting_for_lock = Queue.new
+            end
+
+            def synchronize
+              waiting_for_lock << true if locked?
+
+              @mutex.synchronize do
+                @state_mutex.synchronize { @locked = true }
+                begin
+                  yield
+                ensure
+                  @state_mutex.synchronize { @locked = false }
+                end
+              end
+            end
+
+            def locked?
+              @state_mutex.synchronize { @locked }
+            end
+          end.new
+          allow(described_class).to receive(:terminal_mutex_for).and_return(instrumented_mutex)
+
           release_first_call = Queue.new
           entered_body = Queue.new
           pop_with_timeout = ->(queue) { Timeout.timeout(1) { queue.pop } }
@@ -170,7 +616,7 @@ module CardTerminals
           expect(pop_with_timeout.call(entered_body)).to eq('first')
 
           second_thread = Thread.new { service.verify_pin('second') }
-          sleep 0.05
+          expect(pop_with_timeout.call(instrumented_mutex.waiting_for_lock)).to be(true)
           expect(entered_body).to be_empty
 
           release_first_call << true

--- a/spec/services/card_terminals/rmi/creator_spec.rb
+++ b/spec/services/card_terminals/rmi/creator_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module CardTerminals
+  class RMI
+    RSpec.describe Creator do
+      describe '#save with Cherry ST-1506 info' do
+        let(:info) do
+          CherryV1::Info.new(
+            'providerId' => 'DECHY',
+            'productShortName' => 'ST1506',
+            'deviceName' => 'Cherry ST-1506',
+            'ethernetMacAddress' => 'aa:bb:cc:dd:ee:ff',
+            'ipAddress' => '192.0.2.10',
+            'fwVersion' => '3.2.1',
+            'smcktSerialNumber' => 'CHERRY-SERIAL-123',
+            'smcktProductTypeVersion' => '2.0',
+            'smcktPersonalization' => 'RSA,ECC',
+            'smcktExpirationDateAUT' => '20270131',
+            'smcktExpirationDateAUT2' => '20280229'
+          )
+        end
+
+        it 'updates terminal fields but does not create or link an SMC-KT card without reliable ICCSN and slot' do
+          creator = described_class.new(info: info)
+
+          expect { @save_result = creator.save }.to change(CardTerminal, :count).by(1)
+            .and change(Card, :count).by(0)
+            .and change(CardTerminalSlot, :count).by(0)
+
+          expect(@save_result).to be_truthy
+
+          terminal = creator.card_terminal.reload
+          expect(terminal.mac).to eq('AABBCCDDEEFF')
+          expect(terminal.ip).to eq('192.0.2.10')
+          expect(terminal.name).to eq('Cherry ST-1506')
+          expect(terminal.identification).to eq('DECHY-ST1506')
+          expect(terminal.firmware_version).to eq('3.2.1')
+        end
+
+        it 'preserves existing values for Cherry fields that are not exposed while updating provided fields' do
+          terminal = FactoryBot.create(
+            :card_terminal,
+            mac: 'AABBCCDDEEFF',
+            ip: '198.51.100.1',
+            name: 'Old terminal name',
+            identification: 'OLD-ID',
+            firmware_version: '1.0.0',
+            serial: 'EXISTING-SERIAL',
+            uptime_total: 1234,
+            uptime_reboot: 56,
+            slot1_plug_cycles: 11,
+            slot2_plug_cycles: 22,
+            slot3_plug_cycles: 33,
+            slot4_plug_cycles: 44
+          )
+
+          creator = described_class.new(info: info)
+
+          expect(creator.save).to be_truthy
+
+          terminal.reload
+          expect(terminal.ip).to eq('192.0.2.10')
+          expect(terminal.name).to eq('Cherry ST-1506')
+          expect(terminal.identification).to eq('DECHY-ST1506')
+          expect(terminal.firmware_version).to eq('3.2.1')
+          expect(terminal.serial).to eq('EXISTING-SERIAL')
+          expect(terminal.uptime_total).to eq(1234)
+          expect(terminal.uptime_reboot).to eq(56)
+          expect(terminal.slot1_plug_cycles).to eq(11)
+          expect(terminal.slot2_plug_cycles).to eq(22)
+          expect(terminal.slot3_plug_cycles).to eq(33)
+          expect(terminal.slot4_plug_cycles).to eq(44)
+        end
+      end
+
+      describe '#save with ORGA info' do
+        let(:orga_properties) do
+          {
+            'net_lan_macAddr' => '00:11:22:33:44:aa',
+            'sys_terminalName' => 'ORGA-6100-Terminalname',
+            'net_lan_ipAddr' => '127.1.2.3',
+            'vendor_serialNumber' => 'SERIAL1234',
+            'sys_firmwareVersion' => '4.9.0',
+            'sys_uptime_durationTotal' => '340',
+            'sys_uptime_durationSinceBoot' => '12',
+            'card_slot1_plugCycles' => '101',
+            'card_slot2_plugCycles' => '102',
+            'card_slot3_plugCycles' => '103',
+            'card_slot4_plugCycles' => '104',
+            'vendor_deviceManufacturerId' => 'INGHC',
+            'vendor_deviceModelName' => 'ORGA6100',
+            'card_smkt_iccsn' => '80276123456789011111',
+            'card_smkt_version' => '4.4.1',
+            'card_smkt_slotNum' => smckt_slot,
+            'card_smkt_autType' => 'RSA',
+            'card_smkt_autCxd' => '11.11.2026',
+            'card_smkt_aut2Type' => 'ECC',
+            'card_smkt_aut2Cxd' => '30.08.2030'
+          }
+        end
+        let(:smckt_slot) { 4 }
+        let(:info) { OrgaV1::Info.new(orga_properties) }
+
+        it 'creates and links an SMC-KT card for a positive slot and returns true' do
+          creator = described_class.new(info: info)
+
+          expect { @save_result = creator.save }.to change(CardTerminal, :count).by(1)
+            .and change(Card, :count).by(1)
+            .and change(CardTerminalSlot, :count).by(1)
+
+          expect(@save_result).to be_truthy
+
+          card = Card.find_by!(iccsn: '80276123456789011111')
+          slot = CardTerminalSlot.find_by!(card_terminal_id: creator.card_terminal.id, slotid: 4)
+          expect(card.card_type).to eq('SMC-KT')
+          expect(card.expiration_date).to eq(Date.new(2030, 8, 30))
+          expect(card.card_terminal_slot).to eq(slot)
+        end
+
+
+        it 'does not rewrite card type or expiration date for an existing card with the same ICCSN' do
+          existing_card = FactoryBot.create(
+            :card,
+            iccsn: '80276123456789011111',
+            card_type: 'SMC-B',
+            expiration_date: Date.new(2025, 1, 31)
+          )
+
+          expect(described_class.new(info: info).save).to be_truthy
+
+          existing_card.reload
+          expect(existing_card.card_type).to eq('SMC-B')
+          expect(existing_card.expiration_date).to eq(Date.new(2025, 1, 31))
+          expect(existing_card.card_terminal_slot.slotid).to eq(4)
+        end
+
+
+        it 'clears an older card occupying the target slot before linking the current card' do
+          terminal = FactoryBot.create(:card_terminal, mac: '0011223344AA')
+          slot = FactoryBot.create(:card_terminal_slot, card_terminal: terminal, slotid: 4)
+          old_card = FactoryBot.create(:card, iccsn: '80276123456789000000', card_terminal_slot: slot)
+
+          expect(described_class.new(info: info).save).to be_truthy
+
+          expect(old_card.reload.card_terminal_slot).to be_nil
+          expect(Card.find_by!(iccsn: '80276123456789011111').card_terminal_slot).to eq(slot)
+        end
+
+      end
+    end
+  end
+end

--- a/spec/services/card_terminals/rmi_spec.rb
+++ b/spec/services/card_terminals/rmi_spec.rb
@@ -33,6 +33,7 @@ module CardTerminals
       it { expect(subject.respond_to?(:get_idle_message)).to be_truthy }
       it { expect(subject.respond_to?(:set_idle_message)).to be_truthy }
       it { expect(subject.respond_to?(:verify_pin)).to be_truthy }
+      it { expect(subject.respond_to?(:verify_pin_while)).to be_truthy }
       it { expect(subject.respond_to?(:remote_pairing)).to be_truthy }
       it { expect(subject.respond_to?(:supported?)).to be_truthy }
     end
@@ -104,7 +105,7 @@ module CardTerminals
         instance_double(CardTerminals::RMI::CherryV1,
           supported?: true,
           rmi_port: 443,
-          available_actions: [:verify_pin, :get_info]
+          available_actions: [:verify_pin, :verify_pin_while, :get_info]
         )
       end
 
@@ -135,6 +136,28 @@ module CardTerminals
             end
           end
           expect(called_back).to be_truthy
+        end
+      end
+
+      describe "#verify_pin_while" do
+        let(:block_result) { instance_double('VerifyPinResult') }
+        let(:res) { Result.new(true, 'Success Message', block_result) }
+
+        it "returns a success status with the block result" do
+          expect(cherry_v1).to receive(:verify_pin_while).with('iccsn').and_yield.and_return(res)
+          called_block = false
+
+          status = subject.verify_pin_while('iccsn') { called_block = true }
+
+          called_back = false
+          value = nil
+          status.on_success do |_message, returned_value|
+            called_back = true
+            value = returned_value
+          end
+          expect(called_block).to be_truthy
+          expect(called_back).to be_truthy
+          expect(value).to eq(block_result)
         end
       end
 

--- a/spec/services/card_terminals/rmi_spec.rb
+++ b/spec/services/card_terminals/rmi_spec.rb
@@ -104,7 +104,7 @@ module CardTerminals
         instance_double(CardTerminals::RMI::CherryV1,
           supported?: true,
           rmi_port: 443,
-          available_actions: [:verify_pin]
+          available_actions: [:verify_pin, :get_info]
         )
       end
 
@@ -138,6 +138,25 @@ module CardTerminals
         end
       end
 
+      describe "#get_info" do
+        let(:info) { instance_double(CardTerminals::RMI::CherryV1::Info) }
+        let(:res) { Result.new(true, 'Success Message', info) }
+
+        it "executes callback" do
+          expect(cherry_v1).to receive(:get_info).and_return(res)
+          called_back = false
+          returned_info = nil
+          subject.get_info do |result|
+            result.on_success do |message, value|
+              called_back = true
+              returned_info = value
+            end
+          end
+          expect(called_back).to be_truthy
+          expect(returned_info).to eq(info)
+        end
+      end
+
       describe "#reboot" do
         it "is unsupported" do
           called_back = false
@@ -154,7 +173,7 @@ module CardTerminals
         instance_double(CardTerminals::RMI::CherryV1,
           supported?: true,
           rmi_port: 443,
-          available_actions: [:verify_pin]
+          available_actions: [:verify_pin, :get_info]
         )
       end
 

--- a/spec/services/cocard/soap/base_spec.rb
+++ b/spec/services/cocard/soap/base_spec.rb
@@ -18,5 +18,51 @@ module Cocard::SOAP
         )
       }.to raise_error NotImplementedError
     end
+
+    it "preserves string-keyed SOAP fault trace code and detail in error messages" do
+      savon_client = double('savon_client')
+      soap_fault = Savon::SOAPFault.allocate
+      allow(soap_fault).to receive(:to_hash).and_return(
+        'fault' => {
+          'faultcode' => 'soap:Server',
+          'faultstring' => 'Connector error',
+          'detail' => {
+            'error' => {
+              'trace' => {
+                'code' => '4060',
+                'detail' => 'Ressource belegt'
+              }
+            }
+          }
+        }
+      )
+      allow(savon_client).to receive(:call).and_raise(soap_fault)
+
+      soap_class = Class.new(Cocard::SOAP::Base) do
+        def soap_operation
+          :verify_pin
+        end
+
+        def init_savon_client
+          options.fetch(:savon_client)
+        end
+
+        def check_auth
+          true
+        end
+      end
+
+      result = soap_class.new(
+        connector: double('connector', connector_services: [double('connector_service')]),
+        mandant: 'Ein1',
+        client_system: 'Cocard',
+        workplace: 'Konnektor',
+        savon_client: savon_client
+      ).call
+
+      expect(result).not_to be_success
+      expect(result.error_messages.join(' ')).to include('4060')
+      expect(result.error_messages.join(' ')).to include('Ressource belegt')
+    end
   end
 end

--- a/spec/services/cocard/verify_all_pins_spec.rb
+++ b/spec/services/cocard/verify_all_pins_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+module Cocard
+  RSpec.describe VerifyAllPins do
+    let(:card) { instance_double(Card, card_terminal: terminal, contexts: contexts, iccsn: '80276883110000123456', name: 'SMC-B', to_s: 'SMC-B') }
+    let(:terminal) { instance_double(CardTerminal, pin_mode: 'on', rmi: rmi) }
+    let(:rmi) { instance_double(CardTerminals::RMI, supported?: true, available_actions: [:verify_pin_while]) }
+    let(:contexts) { double('contexts') }
+    let(:context) { instance_double(Context, to_s: 'Kontext') }
+    let(:get_card) { instance_double(Cocard::GetCard, call: Cocard::GetCard::Result.new(success?: true, error_messages: [], card: card)) }
+    let(:verify_result) { Cocard::VerifyPin::Result.new(success?: true, error_messages: [], pin_verify: nil) }
+
+    before do
+      allow(contexts).to receive(:first).and_return(context)
+      allow(contexts).to receive(:where).and_return(contexts)
+      allow(contexts).to receive(:each).and_yield(context)
+      allow(Cocard::GetCard).to receive(:new).with(card: card, context: context).and_return(get_card)
+      allow(Cocard::GetPinStatus).to receive(:new).and_return(instance_double(Cocard::GetPinStatus, call: nil))
+      allow(Turbo::StreamsChannel).to receive(:broadcast_prepend_to)
+      allow_any_instance_of(described_class).to receive(:sleep)
+    end
+
+    it 'uses the ST1506 retry helper inside one verify_pin_while block' do
+      helper = instance_double(Cocard::VerifyPinWithSt1506Retry, call: verify_result)
+      expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+        block.call
+        CardTerminals::RMI::Status.success('ok')
+      end
+      expect(Cocard::VerifyPinWithSt1506Retry).to receive(:new)
+        .with(card: card, context: context).once.and_return(helper)
+      expect(Cocard::VerifyPin).not_to receive(:new)
+
+      result = described_class.new(card: card).call
+
+      expect(result).to be_a(described_class::Result)
+      expect(result).to be_success
+      expect(result.error_messages).to eq([])
+    end
+
+    it 'aggregates ST1506 helper failures from a successful verify_pin_while block' do
+      failed_verify_result = Cocard::VerifyPin::Result.new(success?: false, error_messages: ['verify failed'], pin_verify: nil)
+      helper = instance_double(Cocard::VerifyPinWithSt1506Retry, call: failed_verify_result)
+      expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+        block.call
+        CardTerminals::RMI::Status.success('ok')
+      end
+      expect(Cocard::VerifyPinWithSt1506Retry).to receive(:new)
+        .with(card: card, context: context).once.and_return(helper)
+
+      result = described_class.new(card: card).call
+
+      expect(result).to be_a(described_class::Result)
+      expect(result).not_to be_success
+      expect(result.error_messages).to eq(['verify failed'])
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
+        .with('verify_pins', target: 'toaster', partial: 'shared/turbo_toast', locals: hash_including(status: :alert))
+    end
+
+    it 'returns a failure result and broadcasts an alert when terminal pin mode is off' do
+      allow(terminal).to receive(:pin_mode).and_return('off')
+      expect(Cocard::GetCard).not_to receive(:new)
+
+      result = described_class.new(card: card).call
+
+      expect(result).to be_a(described_class::Result)
+      expect(result).not_to be_success
+      expect(result.error_messages).to eq(["SMC-B Auto-PIN-Mode am Kartenterminal ist off!"])
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
+        .with('verify_pins', target: 'toaster', partial: 'shared/turbo_toast', locals: hash_including(status: :alert))
+    end
+
+    it 'returns a failure result and broadcasts the existing alert when GetCard fails' do
+      allow(get_card).to receive(:call).and_return(
+        Cocard::GetCard::Result.new(success?: false, error_messages: ['get card failed'], card: nil)
+      )
+
+      result = described_class.new(card: card).call
+
+      expect(result).to be_a(described_class::Result)
+      expect(result).not_to be_success
+      expect(result.error_messages).to eq(['get card failed'])
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
+        .with('verify_pins', target: 'toaster', partial: 'shared/turbo_toast', locals: hash_including(status: :alert))
+    end
+
+    it 'returns a failure result and broadcasts an alert when coordinated ST1506 RMI fails' do
+      expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once
+        .and_return(CardTerminals::RMI::Status.failure('st1506 failed'))
+
+      result = described_class.new(card: card).call
+
+      expect(result).to be_a(described_class::Result)
+      expect(result).not_to be_success
+      expect(result.error_messages).to eq(['st1506 failed'])
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
+        .with('verify_pins', target: 'toaster', partial: 'shared/turbo_toast', locals: hash_including(status: :alert))
+    end
+
+    it 'keeps legacy unsupported behavior on the direct VerifyPin path' do
+      allow(rmi).to receive(:supported?).and_return(false)
+      verify_pin = instance_double(Cocard::VerifyPin, call: verify_result)
+      expect(CardTerminals::RMI::VerifyPinJob).to receive(:perform_later).with(card: card)
+      expect(Cocard::VerifyPin).to receive(:new).with(card: card, context: context).once.and_return(verify_pin)
+      expect(Cocard::VerifyPinWithSt1506Retry).not_to receive(:new)
+
+      result = described_class.new(card: card).call
+
+      expect(result).to be_a(described_class::Result)
+      expect(result).to be_success
+      expect(result.error_messages).to eq([])
+    end
+
+    it 'aggregates legacy direct VerifyPin failures' do
+      allow(rmi).to receive(:supported?).and_return(false)
+      failed_verify_result = Cocard::VerifyPin::Result.new(success?: false, error_messages: ['legacy verify failed'], pin_verify: nil)
+      verify_pin = instance_double(Cocard::VerifyPin, call: failed_verify_result)
+      expect(CardTerminals::RMI::VerifyPinJob).to receive(:perform_later).with(card: card)
+      expect(Cocard::VerifyPin).to receive(:new).with(card: card, context: context).once.and_return(verify_pin)
+      expect(Cocard::VerifyPinWithSt1506Retry).not_to receive(:new)
+
+      result = described_class.new(card: card).call
+
+      expect(result).to be_a(described_class::Result)
+      expect(result).not_to be_success
+      expect(result.error_messages).to eq(['legacy verify failed'])
+      expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
+        .with('verify_pins', target: 'toaster', partial: 'shared/turbo_toast', locals: hash_including(status: :alert))
+    end
+  end
+end

--- a/spec/services/cocard/verify_pin_with_st1506_retry_spec.rb
+++ b/spec/services/cocard/verify_pin_with_st1506_retry_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+module Cocard
+  RSpec.describe VerifyPinWithSt1506Retry do
+    let(:card) { instance_double(Card) }
+    let(:context) { instance_double(Context) }
+    let(:pin_verify_4060) do
+      instance_double(Cocard::PinVerify, error_code: '4060', error_text: 'Ressourcenreservierung aktiv')
+    end
+    let(:pin_verify_rejected) do
+      instance_double(Cocard::PinVerify, error_code: '4091', error_text: 'Falsche PIN')
+    end
+    let(:retryable_result) do
+      Cocard::VerifyPin::Result.new(success?: false,
+                                    error_messages: ['ERROR', '4060 Ressourcenreservierung'],
+                                    pin_verify: pin_verify_4060)
+    end
+    let(:success_result) do
+      Cocard::VerifyPin::Result.new(success?: true, error_messages: [], pin_verify: nil)
+    end
+    let(:rejected_result) do
+      Cocard::VerifyPin::Result.new(success?: false,
+                                    error_messages: ['REJECTED', 'Falsche PIN'],
+                                    pin_verify: pin_verify_rejected)
+    end
+
+    subject(:service) do
+      described_class.new(card: card, context: context, retries: 2, delay: 0)
+    end
+
+    before do
+      allow(service).to receive(:sleep)
+    end
+
+    it 'retries connector VerifyPin for trace code 4060 and returns the final result' do
+      verify_pin = instance_double(Cocard::VerifyPin)
+      expect(Cocard::VerifyPin).to receive(:new)
+        .with(card: card, context: context).exactly(2).times.and_return(verify_pin)
+      expect(verify_pin).to receive(:call).ordered.and_return(retryable_result)
+      expect(verify_pin).to receive(:call).ordered.and_return(success_result)
+
+      expect(service.call).to eq(success_result)
+      expect(service).to have_received(:sleep).once.with(0)
+    end
+
+    it 'retries connector VerifyPin for the gemSpec 4060 text "Ressource belegt" even if no code was parsed' do
+      busy_result = Cocard::VerifyPin::Result.new(success?: false,
+                                                  error_messages: ['Technical Error Ressource belegt'],
+                                                  pin_verify: nil)
+      verify_pin = instance_double(Cocard::VerifyPin)
+      expect(Cocard::VerifyPin).to receive(:new)
+        .with(card: card, context: context).exactly(2).times.and_return(verify_pin)
+      expect(verify_pin).to receive(:call).ordered.and_return(busy_result)
+      expect(verify_pin).to receive(:call).ordered.and_return(success_result)
+
+      expect(service.call).to eq(success_result)
+      expect(service).to have_received(:sleep).once.with(0)
+    end
+
+    it 'does not retry wrong PIN or other non-4060 failures' do
+      verify_pin = instance_double(Cocard::VerifyPin)
+      expect(Cocard::VerifyPin).to receive(:new)
+        .with(card: card, context: context).once.and_return(verify_pin)
+      expect(verify_pin).to receive(:call).once.and_return(rejected_result)
+
+      expect(service.call).to eq(rejected_result)
+      expect(service).not_to have_received(:sleep)
+    end
+
+    it 'returns the last 4060 result after exhausting retries' do
+      verify_pin = instance_double(Cocard::VerifyPin)
+      expect(Cocard::VerifyPin).to receive(:new)
+        .with(card: card, context: context).exactly(3).times.and_return(verify_pin)
+      expect(verify_pin).to receive(:call).exactly(3).times.and_return(retryable_result)
+
+      expect(service.call).to eq(retryable_result)
+      expect(service).to have_received(:sleep).twice.with(0)
+    end
+  end
+end


### PR DESCRIPTION
Hier die Erweiterung um get_info mit minimalen Änderungen am bestehenden Code. Leider noch nicht gegen die echten ST1506 getestet. Dies kann ich wahrscheinlich erst am Mittwoch machen.