### PR TITLE
Fix Cherry ST1506 PIN coordination

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -126,13 +126,8 @@ class CardsController < ApplicationController
       status  = :alert
       message = "CardTerminal #{ct} pin mode == off"
     else
-      # start background rmi job
-      CardTerminals::RMI::VerifyPinJob.perform_later(card: @card)
-      # wait some time
-      sleep 3
+      result = Cocard::PinVerificationRunner.new(card: @card).verify(context: set_context)
 
-      # start verify pin
-      result = Cocard::VerifyPin.new(card: @card, context: set_context).call
       unless result.success?
         status  = :alert
         message = (@card.to_s + "<br/>" +

--- a/app/services/card_terminals/rmi.rb
+++ b/app/services/card_terminals/rmi.rb
@@ -25,6 +25,14 @@ module CardTerminals
       rmi.supported?
     end
 
+    def coordinated_verify_pin_supported?
+      supported? && rmi.coordinated_verify_pin_supported?
+    end
+
+    def coordinated_verify_pin_available?
+      coordinated_verify_pin_supported? && available_actions.include?(:verify_pin_while)
+    end
+
     def rmi_port
       rmi.rmi_port
     end
@@ -91,6 +99,19 @@ module CardTerminals
         end
       else
         yield Status.unsupported
+      end
+    end
+
+    def verify_pin_while(iccsn, &block)
+      unless coordinated_verify_pin_available?
+        return Status.unsupported
+      end
+
+      result = rmi.verify_pin_while(iccsn, &block)
+      if result.success?
+        Status.success(result.message.to_s, result.value)
+      else
+        Status.failure(result.message.to_s)
       end
     end
 

--- a/app/services/card_terminals/rmi/base.rb
+++ b/app/services/card_terminals/rmi/base.rb
@@ -32,6 +32,10 @@ module CardTerminals
         false
       end
 
+      def coordinated_verify_pin_supported?
+        false
+      end
+
       def firmware_version
         card_terminal.firmware_version
       end

--- a/app/services/card_terminals/rmi/cherry_v1.rb
+++ b/app/services/card_terminals/rmi/cherry_v1.rb
@@ -26,10 +26,14 @@ module CardTerminals
       def available_actions
         return [] unless supported?
 
-        %i[ verify_pin get_info ]
+        %i[ verify_pin verify_pin_while get_info ]
       end
 
       def supported?
+        true
+      end
+
+      def coordinated_verify_pin_supported?
         true
       end
 
@@ -39,6 +43,14 @@ module CardTerminals
 
       def verify_pin(iccsn)
         self.class.with_verify_pin_lock(card_terminal.id) { verify_pin_without_lock(iccsn) }
+      end
+
+      def verify_pin_while(iccsn, &block)
+        unless block_given?
+          return Result.new(success?: false, message: 'Block is required for ST-1506 PIN verification')
+        end
+
+        self.class.with_verify_pin_lock(card_terminal.id) { verify_pin_while_without_lock(iccsn, &block) }
       end
 
       def get_info
@@ -54,29 +66,20 @@ module CardTerminals
       end
 
       def verify_pin_without_lock(iccsn)
-        unless rmi_port_reachable?
-          return Result.new(success?: false, message: "RMI-Port #{rmi_port} unreachable!")
-        end
+        preflight = verify_pin_preflight(iccsn)
+        return preflight unless preflight.success?
 
-        unless valid_smcb_pin?
-          return Result.new(success?: false, message: 'DEFAULT_SMCB_PIN must be 6 to 8 digits!')
-        end
-        if ws_auth_pass.blank?
-          return Result.new(success?: false, message: 'DEFAULT_WS_AUTH_PASS is not configured!')
-        end
-
-        card_slot_result = card_terminal_slot_for(iccsn)
-        return card_slot_result unless card_slot_result.success?
-
-        key_result = fetch_smcb_authentication_key
-        return key_result unless key_result.success?
-        unless valid_hex?(key_result.value, 64)
-          return Result.new(success?: false, message: 'Invalid ST-1506 SMC-B authentication key')
-        end
-
-        connect_remote_smcb_api(key_result.value, card_slot_result.value.slotid)
+        connect_remote_smcb_api(preflight.value[:key], preflight.value[:slot_id])
       end
       private :verify_pin_without_lock
+
+      def verify_pin_while_without_lock(iccsn, &block)
+        preflight = verify_pin_preflight(iccsn)
+        return preflight unless preflight.success?
+
+        connect_remote_smcb_api_while(preflight.value[:key], preflight.value[:slot_id], &block)
+      end
+      private :verify_pin_while_without_lock
 
       def self.with_verify_pin_lock(terminal_id)
         body_started = false
@@ -362,6 +365,33 @@ module CardTerminals
         end
       end
 
+      def verify_pin_preflight(iccsn)
+        unless rmi_port_reachable?
+          return Result.new(success?: false, message: "RMI-Port #{rmi_port} unreachable!")
+        end
+
+        unless valid_smcb_pin?
+          return Result.new(success?: false, message: 'DEFAULT_SMCB_PIN must be 6 to 8 digits!')
+        end
+        if ws_auth_pass.blank?
+          return Result.new(success?: false, message: 'DEFAULT_WS_AUTH_PASS is not configured!')
+        end
+
+        card_slot_result = card_terminal_slot_for(iccsn)
+        return card_slot_result unless card_slot_result.success?
+
+        key_result = fetch_smcb_authentication_key
+        return key_result unless key_result.success?
+        unless valid_hex?(key_result.value, 64)
+          return Result.new(success?: false, message: 'Invalid ST-1506 SMC-B authentication key')
+        end
+
+        Result.new(success?: true, message: 'ST-1506 PIN verification preflight complete', value: {
+          key: key_result.value,
+          slot_id: card_slot_result.value.slotid
+        })
+      end
+
       def connect_remote_smcb_api(key, authorized_slot_id)
         @result = {}
         @session = {}
@@ -488,12 +518,239 @@ module CardTerminals
         end
       end
 
+      def connect_remote_smcb_api_while(key, authorized_slot_id)
+        @result = {}
+        @session = {}
+        @request = Request.new(session)
+        listener_ready_events = Queue.new
+        auth_events = Queue.new
+        pending_pin_notifies = 0
+        block_finished = false
+        block_value = nil
+        authenticated = false
+        listener_ready_signaled = false
+        auth_signaled = false
+        closed = false
+        ws = nil
+        close_when_block_done = nil
+
+        signal_listener_ready = lambda do
+          next if listener_ready_signaled
+
+          listener_ready_signaled = true
+          listener_ready_events << true
+        end
+        signal_auth = lambda do |status|
+          next if auth_signaled
+
+          auth_signaled = true
+          auth_events << status
+        end
+        close_listener = lambda do
+          listener_ws = ws
+          next unless listener_ws
+
+          schedule_on_eventmachine do
+            listener_ws.close
+          end
+        end
+
+        listener_thread = Thread.new do
+          execute_with_rails_executor do
+            self.class.with_eventmachine_lock do
+              signal_listener_ready.call
+
+              EM.run do
+                ws = Faye::WebSocket::Client.new(ws_url, ['cobra-smcb'], ping: 15, tls: tls_options)
+                auth_timeout = EM::Timer.new(smcb_total_timeout_seconds) do
+                  next if authenticated || @result[:success] || @result[:message].present?
+
+                  @result = { success: false, message: 'Timeout during ST-1506 block PIN verification' }
+                  signal_auth.call(:failed)
+                  ws.close
+                end
+                pending_notify_timeout = nil
+                cancel_pending_notify_timeout = lambda do
+                  pending_notify_timeout.cancel if pending_notify_timeout
+                  pending_notify_timeout = nil
+                end
+
+                close_with_failure = lambda do |message|
+                  next if closed
+
+                  cancel_pending_notify_timeout.call
+                  @result = { success: false, message: message }
+                  signal_auth.call(:failed) unless authenticated
+                  ws.close
+                end
+                schedule_pending_notify_timeout = lambda do
+                  cancel_pending_notify_timeout.call
+                  pending_notify_timeout = EM::Timer.new(smcb_idle_timeout_seconds) do
+                    next if closed || pending_pin_notifies.zero?
+
+                    close_with_failure.call('Timeout waiting for ST-1506 PIN notify completion')
+                  end
+                end
+                close_when_block_done = lambda do
+                  next if closed
+                  next unless block_finished && pending_pin_notifies.zero?
+
+                  cancel_pending_notify_timeout.call
+                  @result = { success: true, message: 'PIN Verification complete', value: block_value } unless @result[:message].present?
+                  ws.close
+                end
+
+                ws.on :open do |_event|
+                  debug('>>> :open cherry remote SMC-B block >>>')
+                end
+
+                ws.on :message do |event|
+                  response = parse_ws_response(event.data)
+                  unless response
+                    signal_auth.call(:failed) unless authenticated
+                    ws.close
+                    next
+                  end
+
+                  debug2(response)
+                  session[:smcb_session_id] = response.session_id if response.session_id.present?
+
+                  if response.authenticate_request?
+                    unless valid_authenticate_request?(response)
+                      close_with_failure.call('Invalid ST-1506 SMC-B authenticate request')
+                      next
+                    end
+
+                    cmac = self.class.aes_cmac_hex(key, response.challenge)
+                    ws.send(request.authenticate_response(response.msg_id, cmac))
+                    authenticated = true
+                    auth_timeout.cancel if auth_timeout
+                    auth_timeout = nil
+                    signal_auth.call(:authenticated)
+                  elsif !authenticated
+                    close_with_failure.call("Unexpected ST-1506 SMC-B response before authentication: #{response.payload_type}")
+                  elsif response.notify?
+                    if response.success?
+                      pending_pin_notifies -= 1 if pending_pin_notifies.positive?
+                      cancel_pending_notify_timeout.call if pending_pin_notifies.zero?
+                      close_when_block_done.call
+                    else
+                      close_with_failure.call("ST-1506 notify code #{response.notify_code}")
+                    end
+                  elsif response.input_pin_request?
+                    unless authorized_pin_request?(response, authorized_slot_id)
+                      close_with_failure.call('ST-1506 PIN request slot is not authorized for this card')
+                      next
+                    end
+
+                    unless pin_allowed_for_request?(response)
+                      close_with_failure.call('Configured SMC-B PIN violates ST-1506 PIN length request')
+                      next
+                    end
+
+                    pending_pin_notifies += 1
+                    schedule_pending_notify_timeout.call
+                    toaster(:info, 'PIN-Anfrage vom ST-1506 erhalten, sende SMC-B PIN ...')
+                    ws.send(request.input_pin_response(response.msg_id, smcb_pin))
+                  elsif response.output_request?
+                    unless authorized_output_request?(response, authorized_slot_id)
+                      close_with_failure.call('ST-1506 output request slot is not authorized for this card')
+                      next
+                    end
+
+                    handle_output_request(ws, response)
+                    close_when_block_done.call
+                  elsif response.cancel?
+                    close_with_failure.call('ST-1506 canceled PIN request')
+                  end
+                end
+
+                ws.on :error do |event|
+                  @result = { success: false, message: event.message }
+                  signal_auth.call(:failed) unless authenticated
+                  debug([:error, event.message])
+                  ws.close
+                end
+
+                ws.on :close do |event|
+                  closed = true
+                  signal_auth.call(:failed) unless authenticated
+                  auth_timeout.cancel if auth_timeout
+                  cancel_pending_notify_timeout.call
+                  debug([:close, event.code, event.reason])
+                  ws = nil
+                  EM.stop
+                end
+              end
+            end
+          end
+        end
+
+        begin
+          Timeout.timeout(smcb_total_timeout_seconds + 1) { listener_ready_events.pop }
+          auth_status = Timeout.timeout(smcb_total_timeout_seconds) { auth_events.pop }
+
+          if auth_status == :authenticated
+            block_value = execute_with_rails_executor { yield }
+            block_finished = true
+            schedule_on_eventmachine do
+              if @result[:message].present?
+                close_listener.call
+              else
+                close_when_block_done.call
+              end
+            end
+          end
+        rescue Timeout::Error
+          if listener_ready_signaled
+            @result = { success: false, message: 'Timeout during ST-1506 PIN verification block' } unless @result[:message].present?
+            close_listener.call
+          else
+            @result = { success: false, message: 'Timeout stopping ST-1506 block PIN verification listener' } unless @result[:message].present?
+            listener_thread.kill unless listener_thread.join(1)
+            listener_thread.join(1)
+          end
+        rescue StandardError => e
+          @result = { success: false, message: "ST-1506 PIN verification block failed: #{e.message}" } unless @result[:message].present?
+          close_listener.call
+        ensure
+          unless listener_thread.join(smcb_total_timeout_seconds + 1)
+            @result = { success: false, message: 'Timeout stopping ST-1506 block PIN verification listener' } unless @result[:message].present?
+            close_listener.call
+            listener_thread.kill unless listener_thread.join(1)
+            listener_thread.join(1)
+          end
+        end
+
+        if @result[:success]
+          Result.new(success?: true, message: @result[:message], value: @result[:value])
+        else
+          Result.new(success?: false, message: @result[:message] || 'PIN Verification failed')
+        end
+      end
+
       def handle_output_request(ws, response)
         toaster(:info, response.message) if response.message.present?
         return unless response.expect_response?
 
         code = response.ok_button? ? 'OkButton' : 'Error'
         ws.send(request.output_response(response.msg_id, code))
+      end
+
+      def schedule_on_eventmachine(&block)
+        if EM.reactor_running?
+          EM.schedule(&block)
+        else
+          block.call
+        end
+      end
+
+      def execute_with_rails_executor
+        if defined?(Rails) && Rails.respond_to?(:application) && Rails.application.respond_to?(:executor)
+          Rails.application.executor.wrap { yield }
+        else
+          yield
+        end
       end
 
       def parse_ws_response(data)

--- a/app/services/card_terminals/rmi/cherry_v1/info.rb
+++ b/app/services/card_terminals/rmi/cherry_v1/info.rb
@@ -205,6 +205,14 @@ module CardTerminals
         nil
       end
 
+      def preserve_nil_terminal_attributes?
+        true
+      end
+
+      def missing_smckt_card_is_success?
+        true
+      end
+
     private
       attr_reader :properties
 

--- a/app/services/card_terminals/rmi/creator.rb
+++ b/app/services/card_terminals/rmi/creator.rb
@@ -13,7 +13,7 @@ module CardTerminals
     # * :info  - CardTerminal::RMI::*::Info object
     #
     def initialize(options = {})
-      options = options.symbolize_keys
+      options.symbolize_keys
       @info = options.fetch(:info)
     end
 
@@ -54,7 +54,7 @@ module CardTerminals
       if @card_terminal.save
         @card_terminal.touch
         result = update_or_create_card
-        return true if cherry_info? && result.nil?
+        return true if missing_smckt_card_is_success? && result.nil?
 
         result
       else
@@ -69,13 +69,21 @@ module CardTerminals
 
     def assign_info_attribute(attribute)
       value = info.public_send(attribute)
-      return if cherry_info? && value.nil?
+      return if preserve_nil_terminal_attributes? && unavailable_terminal_attribute?(value)
 
       @card_terminal.public_send("#{attribute}=", value)
     end
 
-    def cherry_info?
-      info.is_a?(CardTerminals::RMI::CherryV1::Info)
+    def unavailable_terminal_attribute?(value)
+      value.nil? || value == 0
+    end
+
+    def preserve_nil_terminal_attributes?
+      info.respond_to?(:preserve_nil_terminal_attributes?) && info.preserve_nil_terminal_attributes?
+    end
+
+    def missing_smckt_card_is_success?
+      info.respond_to?(:missing_smckt_card_is_success?) && info.missing_smckt_card_is_success?
     end
 
     def update_or_create_card

--- a/app/services/cocard/pin_verification_runner.rb
+++ b/app/services/cocard/pin_verification_runner.rb
@@ -1,0 +1,76 @@
+module Cocard
+  # Coordinates PIN verification across terminal modes while keeping terminal-specific
+  # listener decisions out of controllers and higher-level Cocard services.
+  class PinVerificationRunner
+    Result = ImmutableStruct.new(:success?, :error_messages, :value)
+
+    def initialize(options = {})
+      options = options.symbolize_keys
+      @card = options.fetch(:card)
+    end
+
+    def verify(context:)
+      verification_result = nil
+      coordination_result = verify_contexts do |verifier|
+        verification_result = verifier.call(context)
+      end
+
+      return coordination_result unless coordination_result.success?
+
+      coordination_result.value || verification_result
+    end
+
+    def verify_contexts
+      if coordinated_verify_pin_available?
+        run_coordinated { |verifier| yield(verifier) }
+      else
+        run_legacy { |verifier| yield(verifier) }
+      end
+    end
+
+  private
+    attr_reader :card
+
+    def run_coordinated
+      block_value = nil
+      rmi_status = rmi.verify_pin_while(card.iccsn) do
+        block_value = yield(method(:verify_pin))
+      end
+
+      rmi_error_messages = []
+      rmi_status.on_failure do |rmi_message|
+        rmi_error_messages = Array(rmi_message)
+      end
+      rmi_status.on_unsupported do
+        rmi_error_messages = ["Coordinated PIN verification is not supported by this card terminal."]
+      end
+      return Result.new(success?: false, error_messages: rmi_error_messages, value: nil) if rmi_error_messages.any?
+
+      value = block_value
+      rmi_status.on_success do |_message, status_value|
+        value = status_value unless status_value.nil?
+      end
+      Result.new(success?: true, error_messages: [], value: value)
+    end
+
+    def run_legacy
+      CardTerminals::RMI::VerifyPinJob.perform_later(card: card)
+      sleep 3
+
+      value = yield(method(:verify_pin))
+      Result.new(success?: true, error_messages: [], value: value)
+    end
+
+    def coordinated_verify_pin_available?
+      rmi&.coordinated_verify_pin_available?
+    end
+
+    def verify_pin(context)
+      Cocard::VerifyPin.new(card: card, context: context).call
+    end
+
+    def rmi
+      @rmi ||= card.card_terminal&.rmi
+    end
+  end
+end

--- a/app/services/cocard/verify_all_pins.rb
+++ b/app/services/cocard/verify_all_pins.rb
@@ -28,8 +28,8 @@ module Cocard
     def call
       error_messages = []
       if card.card_terminal&.pin_mode == 'off'
-        error_messages = "SMC-B Auto-PIN-Mode am Kartenterminal ist off!"
-        toaster(card, :alert, error_message)
+        error_messages = ["SMC-B Auto-PIN-Mode am Kartenterminal ist off!"]
+        toaster(card, :alert, error_messages.join(', '))
         return Result.new(success?: false, error_messages: error_messages)
       end
 
@@ -43,45 +43,55 @@ module Cocard
         message = (card.to_s + "<br/>" + "Kontext: #{card.contexts.first}<br/>ERROR:: " +
                    result.error_messages.join(', ')).html_safe
         toaster(card, status, message)
-      else
-
-        #
-        # Background job for auto-enter SMC-B PIN
-        #
-        CardTerminals::RMI::VerifyPinJob.perform_later(card: card)
-        # wait before continue
-        sleep 3
-
-        #
-        # Loop over card contexts
-        #
-        card.contexts.where("card_contexts.pin_status = 'VERIFIABLE'")
-                     .where("card_contexts.left_tries = 3").each do |cctx|
-          # just delay for 2 seconds
-          sleep 2
-          # just for debugging
-          # result = Cocard::GetPinStatus.new(card: card, context: cctx).call
-          result = Cocard::VerifyPin.new(card: card, context: cctx).call
-
-          if result.success?
-            status  = :success
-            message = (card.to_s + "<br/>" + "Kontext: #{cctx}<br/>" +
-                       "VERIFY PIN successful").html_safe
-          else
-            status  = :alert
-            message = (card.to_s + "<br/>" + "Kontext: #{cctx}<br/>ERROR:: " +
-                       result.error_messages.join(', ')).html_safe
-
-          end
-          toaster(card, status, message)
-          # update card pin status
-          Cocard::GetPinStatus.new(card: card, context: cctx).call
-        end
+        return Result.new(success?: false, error_messages: result.error_messages)
       end
+
+      runner = Cocard::PinVerificationRunner.new(card: card)
+      coordination_result = runner.verify_contexts do |verifier|
+        verify_verifiable_contexts(verifier)
+      end
+
+      unless coordination_result.success?
+        rmi_error_messages = coordination_result.error_messages
+        toaster(card, :alert, (card.to_s + "<br/>ERROR:: " + rmi_error_messages.join(', ')).html_safe)
+        return Result.new(success?: false, error_messages: rmi_error_messages)
+      end
+
+      verification_error_messages = Array(coordination_result.value)
+      Result.new(success?: verification_error_messages.empty?, error_messages: verification_error_messages)
     end
 
   private
     attr_reader :card
+
+    def verify_verifiable_contexts(verifier)
+      error_messages = []
+      card.contexts.where("card_contexts.pin_status = 'VERIFIABLE'")
+                   .where("card_contexts.left_tries = 3").each do |cctx|
+        # just delay for 2 seconds
+        sleep 2
+        # just for debugging
+        # result = Cocard::GetPinStatus.new(card: card, context: cctx).call
+        result = verifier.call(cctx)
+
+        if result.success?
+          status  = :success
+          message = (card.to_s + "<br/>" + "Kontext: #{cctx}<br/>" +
+                     "VERIFY PIN successful").html_safe
+        else
+          status  = :alert
+          context_error_messages = Array(result.error_messages)
+          error_messages.concat(context_error_messages)
+          message = (card.to_s + "<br/>" + "Kontext: #{cctx}<br/>ERROR:: " +
+                     context_error_messages.join(', ')).html_safe
+
+        end
+        toaster(card, status, message)
+        # update card pin status
+        Cocard::GetPinStatus.new(card: card, context: cctx).call
+      end
+      error_messages
+    end
 
     def toaster(card, status, message)
       message = "#{card.name}: #{message}"

--- a/spec/requests/cards_spec.rb
+++ b/spec/requests/cards_spec.rb
@@ -194,6 +194,94 @@ RSpec.describe "/cards", type: :request do
     end
   end
 
+  describe "POST /verify_pin" do
+    let(:card) do
+      FactoryBot.create(:card,
+        card_terminal_slot: cts,
+        card_handle: 'card-handle-1',
+        card_type: 'SMC-B'
+      )
+    end
+    let(:rmi) do
+      instance_double(CardTerminals::RMI,
+                      coordinated_verify_pin_available?: true,
+                      coordinated_verify_pin_supported?: true)
+    end
+    let(:verify_result) { Cocard::VerifyPin::Result.new(success?: true, error_messages: [], pin_verify: nil) }
+
+    before do
+      ct.update!(pin_mode: :auto)
+      card.contexts << context
+      allow_any_instance_of(CardTerminal).to receive(:rmi).and_return(rmi)
+    end
+
+    it "uses coordinated PIN verification with plain VerifyPin" do
+      verify_pin = instance_double(Cocard::VerifyPin, call: verify_result)
+      expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+        value = block.call
+        CardTerminals::RMI::Status.success('ok', value)
+      end
+      expect(Cocard::VerifyPin).to receive(:new)
+        .with(card: card, context: context).once.and_return(verify_pin)
+
+      post verify_pin_card_url(card, context_id: context.id)
+
+      expect(response).to be_successful
+    end
+
+    it "renders an alert toast when coordinated PIN verification fails" do
+      expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once
+        .and_return(CardTerminals::RMI::Status.failure('coordination failed'))
+
+      post verify_pin_card_url(card, context_id: context.id)
+
+      expect(response).to be_successful
+      expect(response.body).to include('bg-danger')
+      expect(response.body).to include('ERROR:: coordination failed')
+    end
+
+    it "keeps ORGA-shaped RMI on the legacy VerifyPin job path" do
+      legacy_rmi = instance_double(CardTerminals::RMI,
+                                   coordinated_verify_pin_available?: false,
+                                   coordinated_verify_pin_supported?: false)
+      allow_any_instance_of(CardTerminal).to receive(:rmi).and_return(legacy_rmi)
+      allow_any_instance_of(Cocard::PinVerificationRunner).to receive(:sleep)
+      verify_pin = instance_double(Cocard::VerifyPin, call: verify_result)
+
+      expect(legacy_rmi).not_to receive(:verify_pin_while)
+      expect(CardTerminals::RMI::VerifyPinJob).to receive(:perform_later).with(card: card)
+      expect(Cocard::VerifyPin).to receive(:new).with(card: card, context: context).once.and_return(verify_pin)
+
+      post verify_pin_card_url(card, context_id: context.id)
+
+      expect(response).to be_successful
+    end
+
+    it "renders an alert toast when legacy VerifyPin fails" do
+      legacy_rmi = instance_double(CardTerminals::RMI,
+                                   coordinated_verify_pin_available?: false,
+                                   coordinated_verify_pin_supported?: false)
+      allow_any_instance_of(CardTerminal).to receive(:rmi).and_return(legacy_rmi)
+      allow_any_instance_of(Cocard::PinVerificationRunner).to receive(:sleep)
+      failed_verify_result = Cocard::VerifyPin::Result.new(
+        success?: false,
+        error_messages: ['legacy verify failed'],
+        pin_verify: nil
+      )
+      verify_pin = instance_double(Cocard::VerifyPin, call: failed_verify_result)
+
+      expect(legacy_rmi).not_to receive(:verify_pin_while)
+      expect(CardTerminals::RMI::VerifyPinJob).to receive(:perform_later).with(card: card)
+      expect(Cocard::VerifyPin).to receive(:new).with(card: card, context: context).once.and_return(verify_pin)
+
+      post verify_pin_card_url(card, context_id: context.id)
+
+      expect(response).to be_successful
+      expect(response.body).to include('bg-danger')
+      expect(response.body).to include('ERROR:: legacy verify failed')
+    end
+  end
+
   describe "DELETE /destroy" do
     it "soft_deletes the requested card" do
       card = Card.create! valid_attributes

--- a/spec/services/card_terminals/rmi/cherry_v1_spec.rb
+++ b/spec/services/card_terminals/rmi/cherry_v1_spec.rb
@@ -101,10 +101,10 @@ module CardTerminals
       end
 
       describe '#available_actions' do
-        it 'includes get_info while preserving verify_pin' do
+        it 'includes get_info and Cherry block verification while preserving verify_pin' do
           card_terminal = FactoryBot.create(:card_terminal, :with_mac, ip: '192.0.2.10')
 
-          expect(described_class.new(card_terminal: card_terminal).available_actions).to contain_exactly(:verify_pin, :get_info)
+          expect(described_class.new(card_terminal: card_terminal).available_actions).to contain_exactly(:verify_pin, :verify_pin_while, :get_info)
         end
       end
 
@@ -669,6 +669,45 @@ module CardTerminals
         end
       end
 
+      describe '#verify_pin_while' do
+        let(:card_terminal) { FactoryBot.create(:card_terminal, :with_mac, ip: '192.0.2.10') }
+        let(:service) { described_class.new(card_terminal: card_terminal) }
+        let(:key_result) { described_class::Result.new(success?: true, message: 'key', value: 'a' * 64) }
+
+        before do
+          allow(card_terminal).to receive(:rmi_port).and_return(8443)
+          allow(card_terminal).to receive(:tcp_port_open?).with(8443).and_return(true)
+        end
+
+        it 'validates the card slot and SMC-B key before starting the block listener' do
+          slot = FactoryBot.create(:card_terminal_slot, card_terminal: card_terminal, slotid: 2)
+          FactoryBot.create(:card, iccsn: '802760000000000004', card_terminal_slot: slot)
+          block_called = false
+
+          with_env('DEFAULT_SMCB_PIN' => '123456', 'DEFAULT_WS_AUTH_PASS' => 'secret') do
+            expect(service).to receive(:fetch_smcb_authentication_key).and_return(key_result)
+            expect(service).to receive(:connect_remote_smcb_api_while).with('a' * 64, 2).and_return(described_class::Result.new(success?: true, message: 'ok'))
+
+            result = service.verify_pin_while('802760000000000004') { block_called = true }
+
+            expect(result).to be_success
+            expect(block_called).to be(false)
+          end
+        end
+
+        it 'fails before fetching an SMC-B key when the ICCSN does not belong to this terminal' do
+          with_env('DEFAULT_SMCB_PIN' => '123456', 'DEFAULT_WS_AUTH_PASS' => 'secret') do
+            expect(service).not_to receive(:fetch_smcb_authentication_key)
+            expect(service).not_to receive(:connect_remote_smcb_api_while)
+
+            result = service.verify_pin_while('802760000000000099') { raise 'should not run' }
+
+            expect(result).not_to be_success
+            expect(result.message).to match(/not assigned|ICCSN/)
+          end
+        end
+      end
+
       describe '#connect_remote_smcb_api' do
         let(:card_terminal) { instance_double(CardTerminal, id: 1, ip: '192.0.2.10', rmi_port: 8443) }
         let(:service) { described_class.new(card_terminal: card_terminal) }
@@ -819,6 +858,395 @@ module CardTerminals
 
           def emit_message(data)
             handlers.fetch(:message).call(OpenStruct.new(data: data))
+          end
+        end
+      end
+
+      describe '#connect_remote_smcb_api_while' do
+        let(:card_terminal) { instance_double(CardTerminal, id: 1, ip: '192.0.2.10', rmi_port: 8443) }
+        let(:service) { described_class.new(card_terminal: card_terminal) }
+        let(:websocket) { FakeBlockWebSocket.new }
+        let(:key) { 'a' * 64 }
+        let(:timer) { instance_double(EM::Timer, cancel: true) }
+
+        before do
+          allow(Faye::WebSocket::Client).to receive(:new).and_return(websocket)
+          allow(EM::Timer).to receive(:new) do |_seconds, &block|
+            @timeout_callback = block
+            timer
+          end
+          allow(EM).to receive(:stop)
+          allow(EM).to receive(:reactor_running?).and_return(false)
+          allow(EM).to receive(:run) do |&block|
+            block.call
+            @exercise_websocket.call
+          end
+          allow(service).to receive(:toaster)
+        end
+
+        it 'runs the caller block only after SMC-B authentication, answers multiple authorized PIN requests, and returns the block value' do
+          block_started = Queue.new
+          release_block = Queue.new
+          events = []
+
+          @exercise_websocket = lambda do
+            expect(events).to be_empty
+            websocket.emit_message(authenticate_request)
+            expect(Timeout.timeout(1) { block_started.pop }).to eq(:started)
+            expect(websocket.sent_payload_types).to include('AuthenticateResponse')
+
+            websocket.emit_message(input_pin_request('pin-1', 'Slot1'))
+            websocket.emit_message(success_notify('notify-1'))
+            websocket.emit_message(input_pin_request('pin-2', 'Slot1'))
+            websocket.emit_message(success_notify('notify-2'))
+            release_block << true
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) do
+              events << :block
+              block_started << :started
+              release_block.pop
+              :block_result
+            end
+          end
+
+          expect(events).to eq([:block])
+          expect(websocket.sent_payload_types.count('InputPinResponse')).to eq(2)
+          expect(websocket.close_count).to eq(1)
+          expect(result).to be_success
+          expect(result.value).to eq(:block_result)
+        end
+
+        it 'keeps the listener open after the block until pending PIN notify confirmations arrive' do
+          block_started = Queue.new
+          release_block = Queue.new
+
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            Timeout.timeout(1) { block_started.pop }
+            websocket.emit_message(input_pin_request('pin-1', 'Slot1'))
+            release_block << true
+            sleep 0.05
+            expect(websocket.close_count).to eq(0)
+
+            websocket.emit_message(success_notify('notify-1'))
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) do
+              block_started << true
+              release_block.pop
+            end
+          end
+
+          expect(websocket.close_count).to eq(1)
+          expect(result).to be_success
+        end
+
+        it 'fails via the pending notify timeout when an authenticated PIN request is never confirmed' do
+          block_started = Queue.new
+          release_block = Queue.new
+
+          allow(service).to receive(:smcb_idle_timeout_seconds).and_return(0.01)
+
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            Timeout.timeout(1) { block_started.pop }
+            websocket.emit_message(input_pin_request('pin-1', 'Slot1'))
+            release_block << true
+            @timeout_callback.call
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) do
+              block_started << true
+              release_block.pop
+              :block_result
+            end
+          end
+
+          expect(websocket.sent_payload_types).to include('InputPinResponse')
+          expect(websocket.close_count).to eq(1)
+          expect(result).not_to be_success
+          expect(result.message).to eq('Timeout waiting for ST-1506 PIN notify completion')
+        end
+
+        it 'rejects wrong-slot PIN requests and closes without sending the PIN' do
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            websocket.emit_message(input_pin_request('pin-1', 'Slot2'))
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { sleep 0.01 }
+          end
+
+          expect(websocket.sent_payload_types).not_to include('InputPinResponse')
+          expect(websocket.close_count).to eq(1)
+          expect(result).not_to be_success
+          expect(result.message).to match(/not authorized/)
+        end
+
+        it 'waits for the caller block to finish before returning after a wrong-slot failure' do
+          block_started = Queue.new
+          release_block = Queue.new
+          block_finished = Queue.new
+          returned = Queue.new
+
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            Timeout.timeout(1) { block_started.pop }
+            websocket.emit_message(input_pin_request('pin-1', 'Slot2'))
+          end
+
+          thread = Thread.new do
+            result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+              service.send(:connect_remote_smcb_api_while, key, 1) do
+                block_started << true
+                release_block.pop
+                block_finished << true
+              end
+            end
+            returned << result
+            result
+          end
+
+          sleep 0.2
+          expect(returned).to be_empty
+
+          release_block << true
+          result = Timeout.timeout(1) { returned.pop }
+
+          expect(Timeout.timeout(1) { block_finished.pop }).to be(true)
+          expect(result).not_to be_success
+          expect(result.message).to match(/not authorized/)
+          expect(thread.value).to eq(result)
+        ensure
+          release_block << true if defined?(release_block)
+          thread&.join(1)
+        end
+
+        it 'fails without running the caller block when the auth timer fires before authentication' do
+          @exercise_websocket = lambda do
+            @timeout_callback.call
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { raise 'should not run' }
+          end
+
+          expect(result).not_to be_success
+          expect(result.message).to eq('Timeout during ST-1506 block PIN verification')
+        end
+
+        it 'preserves a pre-auth timeout result when listener shutdown join times out' do
+          allow(service).to receive(:smcb_total_timeout_seconds).and_return(0.01)
+          join_calls = 0
+          allow(Thread).to receive(:new).and_wrap_original do |original, *args, &thread_block|
+            thread = original.call(*args, &thread_block)
+            allow(thread).to receive(:join) do |_timeout = nil|
+              join_calls += 1
+              join_calls == 1 ? nil : true
+            end
+            allow(thread).to receive(:kill).and_return(thread)
+            thread
+          end
+
+          @exercise_websocket = lambda do
+            @timeout_callback.call
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { raise 'should not run' }
+          end
+
+          expect(result).not_to be_success
+          expect(result.message).to eq('Timeout during ST-1506 block PIN verification')
+        end
+
+        it 'does not spend the auth timeout while waiting for the EventMachine lock' do
+          allow(service).to receive(:smcb_total_timeout_seconds).and_return(0.02)
+          allow(described_class).to receive(:with_eventmachine_lock) do |&block|
+            expect(Faye::WebSocket::Client).not_to have_received(:new)
+            sleep 0.06
+            block.call
+          end
+
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { :after_auth }
+          end
+
+          expect(Faye::WebSocket::Client).to have_received(:new).once
+          expect(websocket.close_count).to eq(1)
+          expect(result).to be_success
+          expect(result.value).to eq(:after_auth)
+        end
+
+        it 'does not stop another active reactor when startup times out before this listener starts' do
+          blocked_listener = Queue.new
+
+          allow(service).to receive(:smcb_total_timeout_seconds).and_return(0.01)
+          allow(EM).to receive(:reactor_running?).and_return(true)
+          expect(EM).not_to receive(:schedule)
+          expect(EM).not_to receive(:stop)
+          expect(Faye::WebSocket::Client).not_to receive(:new)
+          allow(described_class).to receive(:with_eventmachine_lock) do
+            blocked_listener.pop
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { raise 'should not run' }
+          end
+
+          expect(websocket.close_count).to eq(0)
+          expect(result).not_to be_success
+          expect(result.message).to eq('Timeout stopping ST-1506 block PIN verification listener')
+        ensure
+          blocked_listener << true if defined?(blocked_listener)
+        end
+
+        it 'ignores the auth timer after authentication while a slow caller block is running' do
+          block_started = Queue.new
+          block_finished = Queue.new
+
+          allow(service).to receive(:smcb_total_timeout_seconds).and_return(0.01)
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            Timeout.timeout(1) { block_started.pop }
+            @timeout_callback.call
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) do
+              block_started << true
+              sleep 0.05
+              block_finished << true
+              :slow_block_result
+            end
+          end
+
+          expect(timer).to have_received(:cancel)
+          expect(Timeout.timeout(1) { block_finished.pop }).to be(true)
+          expect(websocket.close_count).to eq(1)
+          expect(result).to be_success
+          expect(result.value).to eq(:slow_block_result)
+        end
+
+        it 'runs listener thread callbacks and the caller block through the Rails executor' do
+          block_started = Queue.new
+          release_block = Queue.new
+          listener_callback_wrapped = Queue.new
+          caller_wrapped = Queue.new
+          executor = Class.new do
+            def wrap
+              previous = Thread.current[:cherry_v1_executor_wrapped]
+              Thread.current[:cherry_v1_executor_wrapped] = true
+              yield
+            ensure
+              Thread.current[:cherry_v1_executor_wrapped] = previous
+            end
+          end.new
+
+          allow(Rails).to receive(:application).and_return(double('Rails application', executor: executor))
+          expect(service).to receive(:toaster) do
+            listener_callback_wrapped << Thread.current[:cherry_v1_executor_wrapped]
+          end
+
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            Timeout.timeout(1) { block_started.pop }
+            websocket.emit_message(input_pin_request('pin-1', 'Slot1'))
+            websocket.emit_message(success_notify('notify-1'))
+            release_block << true
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) do
+              caller_wrapped << Thread.current[:cherry_v1_executor_wrapped]
+              block_started << true
+              release_block.pop
+              :executor_wrapped
+            end
+          end
+
+          expect(Timeout.timeout(1) { listener_callback_wrapped.pop }).to be(true)
+          expect(Timeout.timeout(1) { caller_wrapped.pop }).to be(true)
+          expect(result).to be_success
+          expect(result.value).to eq(:executor_wrapped)
+        end
+
+        it 'converts block errors to a failure and closes the listener' do
+          @exercise_websocket = lambda do
+            websocket.emit_message(authenticate_request)
+            sleep 0.05
+          end
+
+          result = with_env('DEFAULT_SMCB_PIN' => '123456') do
+            service.send(:connect_remote_smcb_api_while, key, 1) { raise 'connector failed' }
+          end
+
+          expect(websocket.close_count).to eq(1)
+          expect(result).not_to be_success
+          expect(result.message).to match(/connector failed/)
+        end
+
+        def authenticate_request
+          {
+            'PayloadType' => 'AuthenticateRequest',
+            'Header' => { 'MsgId' => 'auth-1', 'SessionId' => 'session-1' },
+            'Payload' => { 'ApiVersion' => '1.0', 'Challenge' => 'b' * 64 }
+          }.to_json
+        end
+
+        def input_pin_request(msg_id, slot)
+          {
+            'PayloadType' => 'InputPinRequest',
+            'Header' => { 'MsgId' => msg_id, 'SessionId' => 'session-1' },
+            'Payload' => { 'Slot' => slot, 'MinLen' => 6, 'MaxLen' => 8 }
+          }.to_json
+        end
+
+        def success_notify(msg_id)
+          {
+            'PayloadType' => 'Notify',
+            'Header' => { 'MsgId' => msg_id, 'SessionId' => 'session-1' },
+            'Payload' => { 'Code' => 0 }
+          }.to_json
+        end
+
+        class FakeBlockWebSocket
+          attr_reader :close_count, :handlers, :sent
+
+          def initialize
+            @close_count = 0
+            @handlers = {}
+            @sent = []
+          end
+
+          def on(event, &block)
+            handlers[event] = block
+          end
+
+          def send(message)
+            sent << message
+          end
+
+          def close
+            @close_count += 1
+            handlers[:close]&.call(OpenStruct.new(code: 1000, reason: 'closed'))
+          end
+
+          def emit_message(data)
+            handlers.fetch(:message).call(OpenStruct.new(data: data))
+          end
+
+          def sent_payload_types
+            sent.map { |message| JSON.parse(message)['PayloadType'] }
           end
         end
       end

--- a/spec/services/card_terminals/rmi/creator_spec.rb
+++ b/spec/services/card_terminals/rmi/creator_spec.rb
@@ -22,6 +22,11 @@ module CardTerminals
           )
         end
 
+        it 'exposes Creator capability methods for Cherry-specific get_info behavior' do
+          expect(info.preserve_nil_terminal_attributes?).to be(true)
+          expect(info.missing_smckt_card_is_success?).to be(true)
+        end
+
         it 'updates terminal fields but does not create or link an SMC-KT card without reliable ICCSN and slot' do
           creator = described_class.new(info: info)
 
@@ -56,6 +61,7 @@ module CardTerminals
             slot4_plug_cycles: 44
           )
 
+          allow(info).to receive(:slot1_plug_cycles).and_return(0)
           creator = described_class.new(info: info)
 
           expect(creator.save).to be_truthy
@@ -103,6 +109,11 @@ module CardTerminals
         let(:smckt_slot) { 4 }
         let(:info) { OrgaV1::Info.new(orga_properties) }
 
+        it 'relies on Creator-local defaults when ORGA info has no Cherry-specific hooks' do
+          expect(info).not_to respond_to(:preserve_nil_terminal_attributes?)
+          expect(info).not_to respond_to(:missing_smckt_card_is_success?)
+        end
+
         it 'creates and links an SMC-KT card for a positive slot and returns true' do
           creator = described_class.new(info: info)
 
@@ -119,6 +130,23 @@ module CardTerminals
           expect(card.card_terminal_slot).to eq(slot)
         end
 
+
+        it 'does not preserve existing terminal values when ORGA reports nil fields' do
+          terminal = FactoryBot.create(
+            :card_terminal,
+            mac: '0011223344AA',
+            serial: 'EXISTING-SERIAL',
+            uptime_total: 1234
+          )
+          orga_properties['vendor_serialNumber'] = nil
+          orga_properties['sys_uptime_durationTotal'] = nil
+
+          expect(described_class.new(info: info).save).to be_truthy
+
+          terminal.reload
+          expect(terminal.serial).to be_nil
+          expect(terminal.uptime_total).to be_nil
+        end
 
         it 'does not rewrite card type or expiration date for an existing card with the same ICCSN' do
           existing_card = FactoryBot.create(

--- a/spec/services/card_terminals/rmi_spec.rb
+++ b/spec/services/card_terminals/rmi_spec.rb
@@ -33,8 +33,33 @@ module CardTerminals
       it { expect(subject.respond_to?(:get_idle_message)).to be_truthy }
       it { expect(subject.respond_to?(:set_idle_message)).to be_truthy }
       it { expect(subject.respond_to?(:verify_pin)).to be_truthy }
+      it { expect(subject.respond_to?(:verify_pin_while)).to be_truthy }
+      it { expect(subject.respond_to?(:coordinated_verify_pin_supported?)).to be_truthy }
+      it { expect(subject.respond_to?(:coordinated_verify_pin_available?)).to be_truthy }
       it { expect(subject.respond_to?(:remote_pairing)).to be_truthy }
       it { expect(subject.respond_to?(:supported?)).to be_truthy }
+    end
+
+    describe "concrete coordinated verify policies" do
+      let(:terminal) { instance_double(CardTerminal, firmware_version: '3.9.1') }
+
+      it "CherryV1 advertises coordinated verify" do
+        rmi = CardTerminals::RMI::CherryV1.new(card_terminal: terminal)
+
+        expect(rmi.available_actions).to include(:verify_pin_while)
+        expect(rmi.coordinated_verify_pin_supported?).to be_truthy
+      end
+
+      it "Base, Null, and ORGA do not opt into coordinated verify" do
+        base = CardTerminals::RMI::Base.new(card_terminal: terminal)
+        null = CardTerminals::RMI::Null.new(card_terminal: terminal)
+        orga = CardTerminals::RMI::OrgaV1.new(card_terminal: terminal)
+
+        [base, null, orga].each do |rmi|
+          expect(rmi.available_actions).not_to include(:verify_pin_while)
+          expect(rmi.coordinated_verify_pin_supported?).to be_falsey
+        end
+      end
     end
 
     describe '::new' do
@@ -58,7 +83,8 @@ module CardTerminals
         instance_double(CardTerminals::RMI::Null, 
           supported?: false, 
           rmi_port: 443,
-          available_actions: []
+          available_actions: [],
+          coordinated_verify_pin_supported?: false,
         )
       end
       before(:each) do
@@ -68,6 +94,7 @@ module CardTerminals
 
       it { expect(subject.supported?).to be_falsey }
       it { expect(subject.rmi_port).to eq(443) }
+      it { expect(subject.coordinated_verify_pin_supported?).to be_falsey }
 
       [:reboot, :get_info, :get_idle_message, :remote_pairing].each do |action|
         describe "##{action}" do
@@ -104,7 +131,8 @@ module CardTerminals
         instance_double(CardTerminals::RMI::CherryV1,
           supported?: true,
           rmi_port: 443,
-          available_actions: [:verify_pin, :get_info]
+          available_actions: [:verify_pin, :verify_pin_while, :get_info],
+          coordinated_verify_pin_supported?: true,
         )
       end
 
@@ -115,6 +143,8 @@ module CardTerminals
 
       it { expect(subject.supported?).to be_truthy }
       it { expect(subject.rmi_port).to eq(443) }
+      it { expect(subject.coordinated_verify_pin_supported?).to be_truthy }
+      it { expect(subject.coordinated_verify_pin_available?).to be_truthy }
 
       context "when the connector reports DECHY-ST1506" do
         before(:each) do
@@ -134,6 +164,51 @@ module CardTerminals
               called_back = true
             end
           end
+          expect(called_back).to be_truthy
+        end
+      end
+
+      describe "#verify_pin_while" do
+        let(:block_result) { instance_double('VerifyPinResult') }
+        let(:res) { Result.new(true, 'Success Message', block_result) }
+
+        it "returns a success status with the block result" do
+          expect(cherry_v1).to receive(:verify_pin_while).with('iccsn').and_yield.and_return(res)
+          called_block = false
+
+          status = subject.verify_pin_while('iccsn') { called_block = true }
+
+          called_back = false
+          value = nil
+          status.on_success do |_message, returned_value|
+            called_back = true
+            value = returned_value
+          end
+          expect(called_block).to be_truthy
+          expect(called_back).to be_truthy
+          expect(value).to eq(block_result)
+        end
+
+        it "is unsupported when coordinated verify is not advertised as an available action" do
+          allow(cherry_v1).to receive(:available_actions).and_return([:verify_pin, :get_info])
+          expect(cherry_v1).not_to receive(:verify_pin_while)
+
+          status = subject.verify_pin_while('iccsn')
+
+          called_back = false
+          status.on_unsupported { called_back = true }
+          expect(called_back).to be_truthy
+        end
+
+        it "is unsupported when coordinated verify policy is disabled even if action is advertised" do
+          allow(cherry_v1).to receive(:coordinated_verify_pin_supported?).and_return(false)
+          allow(cherry_v1).to receive(:available_actions).and_return([:verify_pin, :verify_pin_while, :get_info])
+          expect(cherry_v1).not_to receive(:verify_pin_while)
+
+          status = subject.verify_pin_while('iccsn')
+
+          called_back = false
+          status.on_unsupported { called_back = true }
           expect(called_back).to be_truthy
         end
       end
@@ -173,7 +248,8 @@ module CardTerminals
         instance_double(CardTerminals::RMI::CherryV1,
           supported?: true,
           rmi_port: 443,
-          available_actions: [:verify_pin, :get_info]
+          available_actions: [:verify_pin, :verify_pin_while, :get_info],
+          coordinated_verify_pin_supported?: true,
         )
       end
 
@@ -197,7 +273,8 @@ module CardTerminals
           supported?: true, 
           rmi_port: 443,
           available_actions: [:reboot, :get_info, :get_idle_message, 
-                              :set_idle_message, :verify_pin]
+                              :set_idle_message, :verify_pin],
+          coordinated_verify_pin_supported?: false,
         )
       end
       before(:each) do
@@ -316,7 +393,8 @@ module CardTerminals
         instance_double(CardTerminals::RMI::OrgaV1, 
           supported?: true, 
           rmi_port: 443,
-          available_actions: [:reboot, :get_idle_message, :set_idle_message, :verify_pin, :remote_pairing]
+          available_actions: [:reboot, :get_idle_message, :set_idle_message, :verify_pin, :remote_pairing],
+          coordinated_verify_pin_supported?: false,
         )
       end
       before(:each) do

--- a/spec/services/cocard/pin_verification_runner_spec.rb
+++ b/spec/services/cocard/pin_verification_runner_spec.rb
@@ -1,0 +1,146 @@
+require 'rails_helper'
+
+module Cocard
+  RSpec.describe PinVerificationRunner do
+    subject(:runner) { described_class.new(card: card) }
+
+    let(:card) do
+      instance_double(Card,
+                      card_terminal: terminal,
+                      iccsn: '80276883110000123456')
+    end
+    let(:terminal) { instance_double(CardTerminal, rmi: rmi) }
+    let(:rmi) do
+      instance_double(CardTerminals::RMI,
+                      coordinated_verify_pin_available?: true,
+                      coordinated_verify_pin_supported?: true)
+    end
+    let(:context) { instance_double(Context) }
+    let(:verification_result) do
+      Cocard::VerifyPin::Result.new(success?: true, error_messages: [], pin_verify: nil)
+    end
+
+    describe '#verify_contexts' do
+      it 'returns the yielded verification result from a coordinated success' do
+        expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+          expect(block.call).to eq(verification_result)
+          CardTerminals::RMI::Status.success('ok')
+        end
+
+        result = runner.verify_contexts { |_verifier| verification_result }
+
+        expect(result).to eq(described_class::Result.new(success?: true, error_messages: [], value: verification_result))
+      end
+
+      it 'lets a coordinated success status value override the yielded block value' do
+        status_value = ['status value']
+
+        expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+          block.call
+          CardTerminals::RMI::Status.success('ok', status_value)
+        end
+
+        result = runner.verify_contexts { |_verifier| verification_result }
+
+        expect(result).to eq(described_class::Result.new(success?: true, error_messages: [], value: status_value))
+      end
+
+      it 'uses plain VerifyPin inside a coordinated block' do
+        verify_pin = instance_double(Cocard::VerifyPin, call: verification_result)
+
+        expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+          block.call
+          CardTerminals::RMI::Status.success('ok')
+        end
+        expect(Cocard::VerifyPin).to receive(:new).with(card: card, context: context).once.and_return(verify_pin)
+
+        result = runner.verify_contexts { |verifier| verifier.call(context) }
+
+        expect(result).to eq(described_class::Result.new(success?: true, error_messages: [], value: verification_result))
+      end
+
+      it 'returns a failure result when coordinated verification fails' do
+        expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once
+          .and_return(CardTerminals::RMI::Status.failure('coordinated verification failed'))
+
+        result = runner.verify_contexts { |_verifier| verification_result }
+
+        expect(result).to eq(described_class::Result.new(success?: false, error_messages: ['coordinated verification failed'], value: nil))
+      end
+
+      it 'returns a clear failure result when coordinated verification is unsupported' do
+        expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once
+          .and_return(CardTerminals::RMI::Status.unsupported)
+
+        result = runner.verify_contexts { |_verifier| verification_result }
+
+        expect(result).to eq(
+          described_class::Result.new(
+            success?: false,
+            error_messages: ['Coordinated PIN verification is not supported by this card terminal.'],
+            value: nil
+          )
+        )
+      end
+
+      it 'uses the legacy ORGA-shaped job, wait, and direct VerifyPin path' do
+        allow(rmi).to receive(:coordinated_verify_pin_available?).and_return(false)
+        allow(rmi).to receive(:coordinated_verify_pin_supported?).and_return(false)
+        verify_pin = instance_double(Cocard::VerifyPin, call: verification_result)
+
+        expect(rmi).not_to receive(:verify_pin_while)
+        expect(CardTerminals::RMI::VerifyPinJob).to receive(:perform_later).with(card: card)
+        expect(runner).to receive(:sleep).with(3)
+        expect(Cocard::VerifyPin).to receive(:new).with(card: card, context: context).once.and_return(verify_pin)
+        result = runner.verify_contexts { |verifier| verifier.call(context) }
+
+        expect(result).to eq(described_class::Result.new(success?: true, error_messages: [], value: verification_result))
+      end
+
+      it 'falls back to legacy verification when coordinated action is unavailable' do
+        allow(rmi).to receive(:available_actions).and_return([:verify_pin])
+        allow(rmi).to receive(:coordinated_verify_pin_available?).and_return(false)
+        allow(rmi).to receive(:coordinated_verify_pin_supported?).and_return(true)
+        verify_pin = instance_double(Cocard::VerifyPin, call: verification_result)
+
+        expect(rmi).not_to receive(:verify_pin_while)
+        expect(CardTerminals::RMI::VerifyPinJob).to receive(:perform_later).with(card: card)
+        expect(runner).to receive(:sleep).with(3)
+        expect(Cocard::VerifyPin).to receive(:new).with(card: card, context: context).once.and_return(verify_pin)
+        result = runner.verify_contexts { |verifier| verifier.call(context) }
+
+        expect(result).to eq(described_class::Result.new(success?: true, error_messages: [], value: verification_result))
+      end
+    end
+
+    describe '#verify' do
+      it 'propagates a single-context coordinated verification result' do
+        verify_pin = instance_double(Cocard::VerifyPin, call: verification_result)
+
+        expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+          block.call
+          CardTerminals::RMI::Status.success('ok')
+        end
+        expect(Cocard::VerifyPin).to receive(:new)
+          .with(card: card, context: context).once.and_return(verify_pin)
+
+        expect(runner.verify(context: context)).to eq(verification_result)
+      end
+
+      it 'returns the unsupported failure result for a single context' do
+        expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once
+          .and_return(CardTerminals::RMI::Status.unsupported)
+
+        result = runner.verify(context: context)
+
+        expect(result).to eq(
+          described_class::Result.new(
+            success?: false,
+            error_messages: ['Coordinated PIN verification is not supported by this card terminal.'],
+            value: nil
+          )
+        )
+      end
+    end
+  end
+end

--- a/spec/services/cocard/verify_all_pins_spec.rb
+++ b/spec/services/cocard/verify_all_pins_spec.rb
@@ -1,0 +1,197 @@
+require 'rails_helper'
+
+RSpec.describe Cocard::VerifyAllPins do
+  let(:card) { instance_double(Card, card_terminal: terminal, contexts: contexts, iccsn: '80276883110000123456', name: 'SMC-B', to_s: 'SMC-B') }
+  let(:terminal) { instance_double(CardTerminal, pin_mode: 'on', rmi: rmi) }
+  let(:rmi) do
+    instance_double(CardTerminals::RMI,
+                    coordinated_verify_pin_available?: true,
+                    coordinated_verify_pin_supported?: true)
+  end
+  let(:contexts) { double('contexts') }
+  let(:context) { instance_double(Context, to_s: 'Kontext') }
+  let(:get_card) { instance_double(Cocard::GetCard, call: Cocard::GetCard::Result.new(success?: true, error_messages: [], card: card)) }
+  let(:verify_result) { Cocard::VerifyPin::Result.new(success?: true, error_messages: [], pin_verify: nil) }
+
+  before do
+    allow(contexts).to receive(:first).and_return(context)
+    allow(contexts).to receive(:where).and_return(contexts)
+    allow(contexts).to receive(:each).and_yield(context)
+    allow(Cocard::GetCard).to receive(:new).with(card: card, context: context).and_return(get_card)
+    allow(Cocard::GetPinStatus).to receive(:new).and_return(instance_double(Cocard::GetPinStatus, call: nil))
+    allow(Turbo::StreamsChannel).to receive(:broadcast_prepend_to)
+    allow_any_instance_of(described_class).to receive(:sleep)
+    allow_any_instance_of(Cocard::PinVerificationRunner).to receive(:sleep)
+  end
+
+  it 'uses coordinated PIN verification inside one verify_pin_while block' do
+    verify_pin = instance_double(Cocard::VerifyPin, call: verify_result)
+    expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+      block.call
+      CardTerminals::RMI::Status.success('ok')
+    end
+    expect(Cocard::VerifyPin).to receive(:new)
+      .with(card: card, context: context).once.and_return(verify_pin)
+
+    result = described_class.new(card: card).call
+
+    expect(result).to be_a(described_class::Result)
+    expect(result).to be_success
+    expect(result.error_messages).to eq([])
+  end
+
+  it 'keeps one coordinated listener around multiple per-context VerifyPin calls' do
+    other_context = instance_double(Context, to_s: 'Anderer Kontext')
+    allow(contexts).to receive(:each).and_yield(context).and_yield(other_context)
+    first_verify_pin = instance_double(Cocard::VerifyPin, call: verify_result)
+    second_verify_pin = instance_double(Cocard::VerifyPin, call: verify_result)
+
+    expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+      block.call
+      CardTerminals::RMI::Status.success('ok')
+    end
+    expect(Cocard::VerifyPin).to receive(:new)
+      .with(card: card, context: context).once.and_return(first_verify_pin)
+    expect(Cocard::VerifyPin).to receive(:new)
+      .with(card: card, context: other_context).once.and_return(second_verify_pin)
+
+    result = described_class.new(card: card).call
+
+    expect(result).to be_a(described_class::Result)
+    expect(result).to be_success
+    expect(result.error_messages).to eq([])
+  end
+
+  it 'aggregates coordinated verification failures from a successful verify_pin_while block' do
+    failed_verify_result = Cocard::VerifyPin::Result.new(success?: false, error_messages: ['verify failed'], pin_verify: nil)
+    verify_pin = instance_double(Cocard::VerifyPin, call: failed_verify_result)
+    expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+      block.call
+      CardTerminals::RMI::Status.success('ok')
+    end
+    expect(Cocard::VerifyPin).to receive(:new)
+      .with(card: card, context: context).once.and_return(verify_pin)
+
+    result = described_class.new(card: card).call
+
+    expect(result).to be_a(described_class::Result)
+    expect(result).not_to be_success
+    expect(result.error_messages).to eq(['verify failed'])
+    expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
+      .with('verify_pins', target: 'toaster', partial: 'shared/turbo_toast', locals: hash_including(status: :alert))
+  end
+
+  it 'aggregates distinct failures from multiple coordinated contexts' do
+    other_context = instance_double(Context, to_s: 'Anderer Kontext')
+    allow(contexts).to receive(:each).and_yield(context).and_yield(other_context)
+    first_failed_result = Cocard::VerifyPin::Result.new(success?: false, error_messages: ['first verify failed'], pin_verify: nil)
+    second_failed_result = Cocard::VerifyPin::Result.new(success?: false, error_messages: ['second verify failed'], pin_verify: nil)
+    first_verify_pin = instance_double(Cocard::VerifyPin, call: first_failed_result)
+    second_verify_pin = instance_double(Cocard::VerifyPin, call: second_failed_result)
+
+    expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once do |_iccsn, &block|
+      block.call
+      CardTerminals::RMI::Status.success('ok')
+    end
+    expect(Cocard::VerifyPin).to receive(:new)
+      .with(card: card, context: context).once.and_return(first_verify_pin)
+    expect(Cocard::VerifyPin).to receive(:new)
+      .with(card: card, context: other_context).once.and_return(second_verify_pin)
+
+    result = described_class.new(card: card).call
+
+    expect(result).to be_a(described_class::Result)
+    expect(result).not_to be_success
+    expect(result.error_messages).to eq(['first verify failed', 'second verify failed'])
+    expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
+      .with('verify_pins', target: 'toaster', partial: 'shared/turbo_toast', locals: hash_including(status: :alert))
+      .twice
+  end
+
+  it 'returns a failure result and broadcasts an alert when terminal pin mode is off' do
+    allow(terminal).to receive(:pin_mode).and_return('off')
+    expect(Cocard::GetCard).not_to receive(:new)
+
+    result = described_class.new(card: card).call
+
+    expect(result).to be_a(described_class::Result)
+    expect(result).not_to be_success
+    expect(result.error_messages).to eq(["SMC-B Auto-PIN-Mode am Kartenterminal ist off!"])
+    expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
+      .with('verify_pins', target: 'toaster', partial: 'shared/turbo_toast', locals: hash_including(status: :alert))
+  end
+
+  it 'returns a failure result and broadcasts the existing alert when GetCard fails' do
+    allow(get_card).to receive(:call).and_return(
+      Cocard::GetCard::Result.new(success?: false, error_messages: ['get card failed'], card: nil)
+    )
+
+    result = described_class.new(card: card).call
+
+    expect(result).to be_a(described_class::Result)
+    expect(result).not_to be_success
+    expect(result.error_messages).to eq(['get card failed'])
+    expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
+      .with('verify_pins', target: 'toaster', partial: 'shared/turbo_toast', locals: hash_including(status: :alert))
+  end
+
+  it 'returns a failure result and broadcasts an alert when coordinated RMI fails' do
+    expect(rmi).to receive(:verify_pin_while).with(card.iccsn).once
+      .and_return(CardTerminals::RMI::Status.failure('coordinated verification failed'))
+
+    result = described_class.new(card: card).call
+
+    expect(result).to be_a(described_class::Result)
+    expect(result).not_to be_success
+    expect(result.error_messages).to eq(['coordinated verification failed'])
+    expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
+      .with('verify_pins', target: 'toaster', partial: 'shared/turbo_toast', locals: hash_including(status: :alert))
+  end
+
+  it 'keeps legacy unsupported behavior on the direct VerifyPin path' do
+    allow(rmi).to receive(:coordinated_verify_pin_available?).and_return(false)
+    allow(rmi).to receive(:coordinated_verify_pin_supported?).and_return(false)
+    verify_pin = instance_double(Cocard::VerifyPin, call: verify_result)
+    expect(CardTerminals::RMI::VerifyPinJob).to receive(:perform_later).with(card: card)
+    expect_any_instance_of(Cocard::PinVerificationRunner).to receive(:sleep).with(3).once
+    expect(Cocard::VerifyPin).to receive(:new).with(card: card, context: context).once.and_return(verify_pin)
+
+    result = described_class.new(card: card).call
+
+    expect(result).to be_a(described_class::Result)
+    expect(result).to be_success
+    expect(result.error_messages).to eq([])
+  end
+
+  it 'keeps ORGA-shaped RMI with verify_pin action on the legacy VerifyPin path' do
+    allow(rmi).to receive(:coordinated_verify_pin_available?).and_return(false)
+    allow(rmi).to receive(:coordinated_verify_pin_supported?).and_return(false)
+    verify_pin = instance_double(Cocard::VerifyPin, call: verify_result)
+    expect(rmi).not_to receive(:verify_pin_while)
+    expect(CardTerminals::RMI::VerifyPinJob).to receive(:perform_later).with(card: card)
+    expect(Cocard::VerifyPin).to receive(:new).with(card: card, context: context).once.and_return(verify_pin)
+
+    result = described_class.new(card: card).call
+
+    expect(result).to be_a(described_class::Result)
+    expect(result).to be_success
+    expect(result.error_messages).to eq([])
+  end
+
+  it 'aggregates legacy direct VerifyPin failures' do
+    allow(rmi).to receive(:coordinated_verify_pin_available?).and_return(false)
+    allow(rmi).to receive(:coordinated_verify_pin_supported?).and_return(false)
+    failed_verify_result = Cocard::VerifyPin::Result.new(success?: false, error_messages: ['legacy verify failed'], pin_verify: nil)
+    verify_pin = instance_double(Cocard::VerifyPin, call: failed_verify_result)
+    expect(CardTerminals::RMI::VerifyPinJob).to receive(:perform_later).with(card: card)
+    expect(Cocard::VerifyPin).to receive(:new).with(card: card, context: context).once.and_return(verify_pin)
+
+    result = described_class.new(card: card).call
+
+    expect(result).to be_a(described_class::Result)
+    expect(result).not_to be_success
+    expect(result.error_messages).to eq(['legacy verify failed'])
+    expect(Turbo::StreamsChannel).to have_received(:broadcast_prepend_to)
+      .with('verify_pins', target: 'toaster', partial: 'shared/turbo_toast', locals: hash_including(status: :alert))
+  end
+end


### PR DESCRIPTION
Add Cherry ST1506 support for coordinated remote SMC-B PIN entry while keeping the generic Cocard surface small. The Cherry implementation owns the WebSocket listener/authentication lifecycle, slot validation, SMC-B PIN response handling, and listener timeouts. Generic Cocard code only gets a small coordinated `verify_pin_while` / `PinVerificationRunner` seam so that connector `VerifyPin` calls can run while the Cherry listener is active.

ORGA and other legacy terminals do not opt into coordinated verification and continue to use the existing flow: enqueue `VerifyPinJob`, wait briefly, then run plain `Cocard::VerifyPin`.

Example flow after an ST1506 was temporarily unreachable:
- `get_cards` / `GetPinStatus` runs periodically and marks SMC-B card contexts as `VERIFIABLE` when they are no longer verified;
- `Cards::VerifyAllPinsJob` periodically picks up `Card.verifiable_auto` cards;
- with two SMC-B cards and two contexts each, Cocard processes the cards sequentially;
- for each SMC-B card, `VerifyAllPins` calls `PinVerificationRunner` once and the runner opens one `verify_pin_while(card.iccsn)` listener around the complete context loop for that card;
- both contexts of that card then run plain connector `Cocard::VerifyPin` while the same ST1506 listener remains open;
- after each context, Cocard refreshes PIN state via `GetPinStatus`; per context failures are aggregated in the `VerifyAllPins` result;
- once all contexts for the card are done and the terminal has sent the expected `Notify` messages, the listener closes; the next SMC-B card gets its own listener for its own authorized slot.

The Cherry implementation prevents overlapping connections to the same terminal:
- `CherryV1#verify_pin` and `#verify_pin_while` run under a per-terminal verification lock;
- PostgreSQL advisory locking serializes the terminal across workers and processes, with a process-local mutex fallback for non-PostgreSQL/test cases;
- EventMachine access is also serialized with a process-global reactor mutex, because the EM reactor is process-global.

The worker/listener is bounded so it should not hang indefinitely:
- preflight fails early if the RMI port is unreachable, the SMC-B PIN is invalid, auth config is missing, the card slot cannot be found, or the ST1506 authentication key is invalid;
- listener startup and ST1506 authentication are waited for with explicit timeouts before the connector block is executed;
- after an `InputPinRequest`, a pending-notify timeout closes the listener with a clear failure if no matching `Notify` arrives;
- when the connector block finishes and all pending notifies are complete, the websocket closes normally;
- final cleanup still closes the websocket and joins the listener thread with a bounded timeout, only killing the thread as a last-resort cleanup path.

If the ST1506 is still unreachable, preflight fails, no context is marked as verified, and the next scheduled verification run can try again.